### PR TITLE
[codex] Fix HealthSave API contract edge cases

### DIFF
--- a/API.md
+++ b/API.md
@@ -102,13 +102,17 @@ without requiring a separate `activity_summaries` payload.
 |--------|--------------------------|
 | `step_count` | `steps` |
 | `distance_walking_running` | `distance_m` |
-| `distance_cycling` | `distance_m` |
-| `distance_wheelchair` | `distance_m` |
 | `flights_climbed` | `floors_climbed` |
 | `active_energy_burned` | `active_calories` |
 | `basal_energy_burned` | `total_calories` |
 | `apple_exercise_time` | `active_minutes` |
-| `apple_stand_time` | `stand_hours` |
+
+`apple_stand_time` stays in `quantity_samples` because HealthKit sends it in
+minutes, while `daily_activity.stand_hours` is populated from
+`activity_summaries.appleStandHours`. `distance_cycling` and
+`distance_wheelchair` also stay in `quantity_samples`; the reference schema has
+only one `daily_activity.distance_m` column, so mapping multiple sport-specific
+distance totals into it would make the stored value depend on batch order.
 
 ### Blood Pressure Correlation
 
@@ -122,13 +126,51 @@ The server preserves the inner metric name when storing to `quantity_samples`.
 
 ### ECG
 
-`ecg` batches are accepted and stored in `quantity_samples`.
+`ecg` batches are accepted for compatibility. HealthSave ECG samples can
+include `start`, `end`, `classification`, `numberOfVoltageMeasurements`,
+`samplingFrequency`, and `averageHeartRate`. ECG records are not persisted by
+this small-footprint server because the current schema has no ECG table.
+
+### Workout Payload Details
+
+Workout samples can include these fields:
+
+```json
+{
+  "name": "Running",
+  "start": "2026-04-10T07:00:00Z",
+  "end": "2026-04-10T07:45:00Z",
+  "duration": 2700,
+  "source": "Apple Watch",
+  "activeEnergy": 420,
+  "distance": 6500,
+  "avgHeartRate": 145,
+  "maxHeartRate": 178,
+  "heartRateData": [
+    {"date": "2026-04-10T07:01:00Z", "qty": 132}
+  ],
+  "route": [
+    {
+      "latitude": 41.01,
+      "longitude": 28.97,
+      "altitude": 42.0,
+      "speed": 2.8,
+      "timestamp": "2026-04-10T07:01:00Z"
+    }
+  ]
+}
+```
+
+The reference server stores the workout summary fields in `workouts`.
+`heartRateData` and `route` are accepted as part of the client payload but are
+not persisted by this small-footprint server.
 
 ### Full HealthKit Metric Catalog
 
 The server accepts any metric name. Below is the complete catalog of metrics
-that HealthSave can send. Metrics not listed above as dedicated or daily
-activity types are stored in `quantity_samples`.
+that HealthSave can send. Quantity-like metrics not listed above as dedicated
+or daily activity types are stored in `quantity_samples` when each sample has
+`date` and `qty` fields.
 
 **Heart & Cardiovascular:**
 `heart_rate`, `resting_heart_rate`, `walking_heart_rate_average`,
@@ -306,5 +348,6 @@ not compatible with the current iOS status UI.
 - Date-only daily activity values can use `YYYY-MM-DD` or an ISO timestamp.
 - Batch ingestion is idempotent for first-class time-series tables through
   `ON CONFLICT` upserts.
-- Unknown metric names are intentionally accepted so new HealthKit types can
-  be stored before they receive first-class dashboards.
+- Unknown metric names are intentionally accepted. Unknown quantity-like
+  samples with `date` and `qty` can be stored before they receive first-class
+  dashboards.

--- a/server.py
+++ b/server.py
@@ -121,13 +121,10 @@ ACTIVITY_FIELDS = {
 DAILY_ACTIVITY_QUANTITY_FIELDS = {
     "step_count": ("steps", to_int),
     "distance_walking_running": ("distance_m", to_float),
-    "distance_cycling": ("distance_m", to_float),
-    "distance_wheelchair": ("distance_m", to_float),
     "flights_climbed": ("floors_climbed", to_int),
     "active_energy_burned": ("active_calories", to_float),
     "basal_energy_burned": ("total_calories", to_float),
     "apple_exercise_time": ("active_minutes", to_int),
-    "apple_stand_time": ("stand_hours", to_int),
 }
 
 

--- a/tests/test_api_contract.py
+++ b/tests/test_api_contract.py
@@ -127,6 +127,32 @@ async def test_step_count_daily_totals_populate_daily_activity():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("metric", ["apple_stand_time", "distance_cycling", "distance_wheelchair"])
+async def test_non_summary_daily_metrics_remain_quantity_samples(metric):
+    session = FakeSession()
+    request = FakeRequest(
+        {
+            "metric": metric,
+            "samples": [
+                {
+                    "date": "2026-04-10T00:00:00+00:00",
+                    "qty": 42,
+                    "source": "HealthKit Statistics",
+                }
+            ],
+        }
+    )
+
+    result = await server.apple_batch(request, session)
+
+    insert_params = session.insert_params_for("quantity_samples")
+    assert result["records"] == 1
+    assert insert_params is not None
+    assert insert_params["metric"] == metric
+    assert session.insert_params_for("daily_activity") is None
+
+
+@pytest.mark.asyncio
 async def test_blood_pressure_correlation_preserves_inner_metric_names():
     session = FakeSession()
     request = FakeRequest(
@@ -357,3 +383,22 @@ def test_api_spec_documents_full_healthsave_metric_catalog():
 
     missing = [metric for metric in expected_metrics if f"`{metric}`" not in api_doc]
     assert missing == []
+
+
+def test_api_spec_documents_quantity_sample_exceptions_and_workout_nested_fields():
+    api_doc = Path("API.md").read_text()
+
+    assert "`apple_stand_time` stays in `quantity_samples`" in api_doc
+    assert "`distance_cycling`" in api_doc
+    assert "`distance_wheelchair`" in api_doc
+    assert "`heartRateData`" in api_doc
+    assert "`route`" in api_doc
+    assert "not persisted by this small-footprint server" in api_doc
+
+
+def test_api_spec_documents_ecg_as_accepted_but_not_persisted():
+    api_doc = Path("API.md").read_text()
+    compact_doc = " ".join(api_doc.split())
+
+    assert "`ecg` batches are accepted for compatibility" in compact_doc
+    assert "ECG records are not persisted by this small-footprint server" in compact_doc


### PR DESCRIPTION
## Summary

- Stop mapping `apple_stand_time` into `daily_activity.stand_hours`; HealthKit sends it as minutes, so it remains a generic `quantity_samples` metric unless the schema gains a stand-minutes column.
- Stop mapping `distance_cycling` and `distance_wheelchair` into the single `daily_activity.distance_m` column to avoid order-dependent overwrites.
- Clarify the API docs for these exceptions, workout nested payload fields (`heartRateData`, `route`), and ECG compatibility behavior.
- Add contract tests covering the daily metric exceptions and documentation guarantees.

## Verification

- `pytest -q tests/test_api_contract.py` -> 10 passed
- `pytest -q` -> 10 passed
- `ruff check server.py tests/test_api_contract.py` -> All checks passed
- `python -m compileall server.py` -> exit 0
- `git diff --check` -> no issues