### PR TITLE
feat(metrics): Prometheus /metrics endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,10 +248,45 @@ To opt into Ollama manually, copy `docker-compose.override.yml.example` to `dock
 | `/api/insights/anomalies` | GET | Recent anomaly findings, filterable by `since` and `severity` |
 | `/api/insights/trends` | GET | Recent HR / HRV trend findings, filterable by `period=30d` |
 | `/api/insights/trigger` | POST | Run an analysis pass now (if AI enabled) |
+| `/metrics` | GET | Prometheus text exposition (no auth, DB-independent) |
 
 `/api/apple/status` intentionally returns top-level metric objects, not a
 wrapped `{"status":"ok","counts":...}` payload. See [API.md](API.md) for
 the compatibility contract.
+
+### Prometheus Metrics
+
+`/metrics` exposes runtime counters and a histogram in Prometheus text
+exposition format. The endpoint is unauthenticated by design (so scrapers
+do not need `X-API-Key`) and does not touch the database, so it returns
+200 even when Postgres is down — safe to use as a liveness target.
+
+| Metric | Type | Labels | Meaning |
+|--------|------|--------|---------|
+| `hdh_ingest_batches_total` | counter | `metric` | Batches accepted by `/api/apple/batch`, including empty ones |
+| `hdh_ingest_rows_total` | counter | `metric` | Rows persisted per metric (cumulative) |
+| `hdh_ingest_duration_seconds` | histogram | `metric` | End-to-end batch handler latency |
+| `hdh_ai_briefing_runs_total` | counter | `job`, `result` | Daily briefing / anomaly check / trend analysis runs by outcome (`success` / `failure`) |
+
+Prometheus scrape config:
+
+```yaml
+scrape_configs:
+  - job_name: health-data-hub
+    metrics_path: /metrics
+    static_configs:
+      - targets: ['health-data-hub:8000']  # or 'localhost:8000' for host scrape
+```
+
+Sample Grafana panel — rows ingested per second, broken down by metric
+(Time series panel):
+
+```promql
+sum by (metric) (rate(hdh_ingest_rows_total[5m]))
+```
+
+Pair `rate(hdh_ai_briefing_runs_total{result="failure"}[1h])` with an
+alert if you want a heads-up when nightly analysis starts failing.
 
 ### Grafana Dashboards
 

--- a/analysis/engine.py
+++ b/analysis/engine.py
@@ -13,9 +13,10 @@ from __future__ import annotations
 
 import json
 import logging
+from collections.abc import Awaitable, Callable
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime, timedelta
-from typing import Any
+from typing import Any, TypeVar
 
 from sqlalchemy import text
 
@@ -28,6 +29,7 @@ from .types import Anomaly, Finding, Insight
 log = logging.getLogger("healthsave.analysis")
 
 _TREND_METRICS = ("heart_rate", "hrv")
+_T = TypeVar("_T")
 
 
 class AnalysisEngine:
@@ -49,6 +51,9 @@ class AnalysisEngine:
         self.trend_analyzer = TrendAnalyzer(session_factory)
 
     async def run_daily_briefing(self) -> int | None:
+        return await self._run_job_with_metrics("daily_briefing", self._run_daily_briefing_impl)
+
+    async def _run_daily_briefing_impl(self) -> int | None:
         """Produce yesterday's narrative morning briefing.
 
         Returns the newly-created ``analysis_runs.id`` on a completed run,
@@ -145,6 +150,9 @@ class AnalysisEngine:
             return run_id
 
     async def run_anomaly_check(self) -> int | None:
+        return await self._run_job_with_metrics("anomaly_check", self._run_anomaly_check_impl)
+
+    async def _run_anomaly_check_impl(self) -> int | None:
         """Lightweight detector run with no LLM narration.
 
         Persists an ``analysis_runs`` row with ``run_type='anomaly_check'``
@@ -189,6 +197,9 @@ class AnalysisEngine:
         )
 
     async def run_trend_analysis(self) -> list[Finding]:
+        return await self._run_job_with_metrics("trend_analysis", self._run_trend_analysis_impl)
+
+    async def _run_trend_analysis_impl(self) -> list[Finding]:
         """Compute trend findings across enabled metrics."""
         async with (
             self.session_factory() as session,
@@ -231,6 +242,19 @@ class AnalysisEngine:
     # ──────────────────────────────────────────────────────────────
     #  Internals
     # ──────────────────────────────────────────────────────────────
+
+    async def _run_job_with_metrics(self, job: str, runner: Callable[[], Awaitable[_T]]) -> _T:
+        # Lazy import: server.api.metrics → server.main → analysis.engine would cycle.
+        from server.api.metrics import AI_BRIEFING_RUNS
+
+        try:
+            result = await runner()
+        except Exception:
+            AI_BRIEFING_RUNS.labels(job=job, result="failure").inc()
+            raise
+
+        AI_BRIEFING_RUNS.labels(job=job, result="success").inc()
+        return result
 
     @asynccontextmanager
     async def _run_context(self, session, run_type: str):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ dependencies = [
     "asyncpg==0.30.0",
     "litellm>=1.40.0",
     "apscheduler>=3.10.0",
+    "prometheus-client>=0.21.0",
     "pyyaml>=6.0",
     "scipy>=1.14.0",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,5 @@ sqlalchemy[asyncio]==2.0.35
 asyncpg==0.30.0
 litellm>=1.40.0
 apscheduler>=3.10.0
+prometheus-client>=0.21.0
 pyyaml>=6.0

--- a/server/api/ingest.py
+++ b/server/api/ingest.py
@@ -1,6 +1,7 @@
 """POST /api/apple/batch - receive a metric batch from a HealthSave client."""
 
 import logging
+from time import perf_counter
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
 from pydantic import ValidationError
@@ -15,6 +16,7 @@ from ..ingestion.handlers import (
 from ..ingestion.parsers import group_samples_by_device
 from ..models.batch import BatchPayload
 from .deps import get_session, verify_api_key
+from .metrics import INGEST_BATCHES, INGEST_DURATION, INGEST_ROWS
 
 log = logging.getLogger("healthsave")
 
@@ -40,6 +42,7 @@ async def apple_batch(
         ]
     }
     """
+    started_at = perf_counter()
     raw_payload = await request.json()
     try:
         payload = BatchPayload.model_validate(raw_payload)
@@ -56,6 +59,7 @@ async def apple_batch(
         await session.commit()
         await _mark_raw_ingestion_processed(session, raw_log_id)
         await session.commit()
+        _observe_ingest_metrics(metric=metric, rows=0, started_at=started_at)
         return {"status": "empty", "metric": metric, "batch": batch_idx, "records": 0}
 
     sample_groups = group_samples_by_device(samples)
@@ -75,6 +79,7 @@ async def apple_batch(
 
     await _mark_raw_ingestion_processed(session, raw_log_id)
     await session.commit()
+    _observe_ingest_metrics(metric=metric, rows=count, started_at=started_at)
     log.info("Ingested %d records for %s (batch %d/%d)", count, metric, batch_idx + 1, total)
     _schedule_anomaly_check_if_enabled(request, background_tasks, count)
 
@@ -85,6 +90,13 @@ async def apple_batch(
         "total_batches": total,
         "records": count,
     }
+
+
+def _observe_ingest_metrics(*, metric: str, rows: int, started_at: float) -> None:
+    """Record one completed batch after validation and persistence succeed."""
+    INGEST_BATCHES.labels(metric=metric).inc()
+    INGEST_ROWS.labels(metric=metric).inc(rows)
+    INGEST_DURATION.labels(metric=metric).observe(perf_counter() - started_at)
 
 
 def _schedule_anomaly_check_if_enabled(

--- a/server/api/metrics.py
+++ b/server/api/metrics.py
@@ -1,0 +1,48 @@
+"""Prometheus metrics endpoint and shared metric collectors."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Response
+from prometheus_client import CONTENT_TYPE_LATEST, Counter, Histogram, generate_latest
+from prometheus_client.metrics import MetricWrapperBase
+
+router = APIRouter()
+
+INGEST_BATCHES = Counter(
+    "hdh_ingest_batches",
+    "Number of ingest batches accepted by the API.",
+    ["metric"],
+)
+INGEST_ROWS = Counter(
+    "hdh_ingest_rows",
+    "Number of rows processed by the ingest API.",
+    ["metric"],
+)
+AI_BRIEFING_RUNS = Counter(
+    "hdh_ai_briefing_runs",
+    "Analysis job runs partitioned by job and result.",
+    ["job", "result"],
+)
+INGEST_DURATION = Histogram(
+    "hdh_ingest_duration_seconds",
+    "End-to-end ingest handler duration in seconds.",
+    ["metric"],
+)
+
+
+@router.get("/metrics")
+async def prometheus_metrics() -> Response:
+    return Response(content=generate_latest(), media_type=CONTENT_TYPE_LATEST)
+
+
+def reset_metrics() -> None:
+    """Clear label children so tests start from a deterministic registry state."""
+    _reset_metric_children(INGEST_BATCHES)
+    _reset_metric_children(INGEST_ROWS)
+    _reset_metric_children(AI_BRIEFING_RUNS)
+    _reset_metric_children(INGEST_DURATION)
+
+
+def _reset_metric_children(metric: MetricWrapperBase) -> None:
+    with metric._lock:
+        metric._metrics.clear()

--- a/server/main.py
+++ b/server/main.py
@@ -23,7 +23,7 @@ from analysis.engine import AnalysisEngine
 from analysis.llm.client import HealthLLMClient
 from analysis.scheduler import AnalysisScheduler
 
-from .api import health_routes, ingest, insights, status
+from .api import health_routes, ingest, insights, metrics, status
 from .db.session import async_session, engine
 
 log = logging.getLogger("healthsave")
@@ -53,5 +53,6 @@ app = FastAPI(title="Health Data Hub", version="1.0.0", lifespan=lifespan)
 
 app.include_router(health_routes.router)
 app.include_router(ingest.router)
+app.include_router(metrics.router)
 app.include_router(status.router)
 app.include_router(insights.router)

--- a/tests/test_metrics_endpoint.py
+++ b/tests/test_metrics_endpoint.py
@@ -1,0 +1,173 @@
+"""Tests for Prometheus metrics exposure and instrumentation."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import server  # noqa: E402
+from analysis.config import AnalysisConfig  # noqa: E402
+from analysis.engine import AnalysisEngine  # noqa: E402
+from server.api.deps import get_session  # noqa: E402
+from server.api.metrics import (  # noqa: E402
+    AI_BRIEFING_RUNS,
+    INGEST_BATCHES,
+    INGEST_DURATION,
+    INGEST_ROWS,
+    reset_metrics,
+)
+from tests.test_api_contract import FakeRequest, FakeSession  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def reset_metric_state():
+    reset_metrics()
+    yield
+    reset_metrics()
+
+
+def _counter_value(counter, **labels) -> float:
+    return counter.labels(**labels)._value.get()
+
+
+def _histogram_count(histogram, **labels) -> float:
+    target = {k: str(v) for k, v in labels.items()}
+    suffix = f"{histogram._name}_count"
+    for family in histogram.collect():
+        for sample in family.samples:
+            if sample.name == suffix and sample.labels == target:
+                return sample.value
+    return 0.0
+
+
+def test_metrics_endpoint_returns_prometheus_text_with_expected_metric_names():
+    with TestClient(server.app) as client:
+        response = client.get("/metrics")
+
+    assert response.status_code == 200
+    # prometheus_client returns "text/plain; version=...; charset=utf-8" — accept any version
+    assert response.headers["content-type"].startswith("text/plain")
+    assert "hdh_ingest_batches_total" in response.text
+    assert "hdh_ingest_rows_total" in response.text
+    assert "hdh_ai_briefing_runs_total" in response.text
+    assert "hdh_ingest_duration_seconds" in response.text
+
+
+def test_metrics_endpoint_returns_200_even_when_db_dependency_is_broken():
+    async def broken_session():
+        raise RuntimeError("database is unavailable")
+        yield
+
+    server.app.dependency_overrides[get_session] = broken_session
+    try:
+        with TestClient(server.app) as client:
+            response = client.get("/metrics")
+    finally:
+        server.app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_ingest_metrics_increment_for_processed_batch():
+    session = FakeSession()
+    request = FakeRequest(
+        {
+            "metric": "heart_rate",
+            "samples": [
+                {
+                    "date": "2026-04-10T12:00:00+00:00",
+                    "qty": 72,
+                    "source": "Apple Watch",
+                }
+            ],
+        }
+    )
+
+    result = await server.apple_batch(request, session)
+
+    assert result["records"] == 1
+    assert _counter_value(INGEST_BATCHES, metric="heart_rate") == 1
+    assert _counter_value(INGEST_ROWS, metric="heart_rate") == 1
+    assert _histogram_count(INGEST_DURATION, metric="heart_rate") == 1
+
+
+@pytest.mark.asyncio
+async def test_ingest_metrics_count_empty_batches_without_rows():
+    session = FakeSession()
+    request = FakeRequest(
+        {
+            "metric": "heart_rate",
+            "samples": [],
+        }
+    )
+
+    result = await server.apple_batch(request, session)
+
+    assert result["status"] == "empty"
+    assert _counter_value(INGEST_BATCHES, metric="heart_rate") == 1
+    assert _counter_value(INGEST_ROWS, metric="heart_rate") == 0
+    assert _histogram_count(INGEST_DURATION, metric="heart_rate") == 1
+
+
+@pytest.mark.asyncio
+async def test_validation_errors_do_not_increment_ingest_metrics():
+    session = FakeSession()
+    # samples must be a list[dict]; passing a string forces ValidationError → HTTP 422
+    request = FakeRequest({"metric": "heart_rate", "samples": "not-a-list"})
+
+    with pytest.raises(Exception) as exc_info:
+        await server.apple_batch(request, session)
+
+    assert getattr(exc_info.value, "status_code", None) == 422
+    assert _counter_value(INGEST_BATCHES, metric="heart_rate") == 0
+    assert _counter_value(INGEST_ROWS, metric="heart_rate") == 0
+    assert _histogram_count(INGEST_DURATION, metric="heart_rate") == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("method_name", "job"),
+    [
+        ("run_daily_briefing", "daily_briefing"),
+        ("run_anomaly_check", "anomaly_check"),
+        ("run_trend_analysis", "trend_analysis"),
+    ],
+)
+async def test_ai_briefing_metrics_count_none_returns_as_success(method_name: str, job: str):
+    engine = AnalysisEngine(lambda: None, AsyncMock(), AnalysisConfig())
+    impl_name = f"_{method_name}_impl"
+    setattr(engine, impl_name, AsyncMock(return_value=None))
+
+    result = await getattr(engine, method_name)()
+
+    assert result is None
+    assert _counter_value(AI_BRIEFING_RUNS, job=job, result="success") == 1
+    assert _counter_value(AI_BRIEFING_RUNS, job=job, result="failure") == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("method_name", "job"),
+    [
+        ("run_daily_briefing", "daily_briefing"),
+        ("run_anomaly_check", "anomaly_check"),
+        ("run_trend_analysis", "trend_analysis"),
+    ],
+)
+async def test_ai_briefing_metrics_count_failures_and_reraise(method_name: str, job: str):
+    engine = AnalysisEngine(lambda: None, AsyncMock(), AnalysisConfig())
+    impl_name = f"_{method_name}_impl"
+    setattr(engine, impl_name, AsyncMock(side_effect=RuntimeError("boom")))
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await getattr(engine, method_name)()
+
+    assert _counter_value(AI_BRIEFING_RUNS, job=job, result="success") == 0
+    assert _counter_value(AI_BRIEFING_RUNS, job=job, result="failure") == 1


### PR DESCRIPTION
Closes #6

## What's included

- New router `server/api/metrics.py` exposing `GET /metrics` in Prometheus text exposition format. **Unauthenticated by design** (scrapers don't carry `X-API-Key`) and **DB-independent** (safe as a liveness target).
- Ingest handler (`server/api/ingest.py`) instrumented for processed and empty-batch paths. `ValidationError` → 422 deliberately does **not** increment counters.
- Analysis engine (`analysis/engine.py`) wraps `run_daily_briefing`, `run_anomaly_check`, `run_trend_analysis` with a `_run_job_with_metrics` decorator that records `success` on completion (including None-returning skipped runs) and `failure` on exceptions before re-raising. Metric is lazy-imported inside the wrapper to break a `server.api.metrics → server.main → analysis.engine` cycle.
- README: new "Prometheus Metrics" section with metric table, scrape config snippet, a sample PromQL panel, and a failure-rate alert hint. Endpoint also added to the API table.
- 11 tests in `tests/test_metrics_endpoint.py` covering endpoint shape, DB-down resilience, ingest counter increments (processed + empty + validation-error paths), and AI briefing success/failure for all three jobs. All use the existing `FakeSession` mock pattern — no live DB needed.

## Acceptance criteria checklist

- [x] `/metrics` returns Prometheus text exposition format
- [x] Counters: `hdh_ingest_batches_total`, `hdh_ingest_rows_total`, `hdh_ai_briefing_runs_total`
- [x] Histogram: `hdh_ingest_duration_seconds`
- [x] README documents scrape config + sample Grafana panel
- [x] Endpoint returns 200 even when database is down (verified by `test_metrics_endpoint_returns_200_even_when_db_dependency_is_broken`)

## Notes / deviations

- Counters use `metric` label so "rows-per-second by table" is queryable as `sum by (metric) (rate(hdh_ingest_rows_total[5m]))`. The metric-name set is bounded so cardinality stays controlled.
- `hdh_ai_briefing_runs_total` carries both `job` and `result` labels (`success` / `failure`) so a single counter answers "how often did each analysis job succeed vs. fail."
- `prometheus-client>=0.21.0` added to both `pyproject.toml` and `requirements.txt`.

## Quality gates

- `ruff format --check .` clean
- `ruff check .` clean
- `pytest -q` — 89 passed (11 new + 78 existing)