### PR TITLE
feat(garmin): import script for Garmin Connect exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ You point your iPhone at it. It stores everything from your Apple Watch (heart r
 - A long-term store for every Apple Health metric your phone collects, queryable with normal SQL
 - A set of ready-made Grafana dashboards (heart, sleep, activity, workouts) that work the moment data starts flowing
 - An optional AI briefing system that turns numbers into plain English ("HRV trended down three days in a row, sleep was light last night, expect a low-energy morning")
-- A clean ingest API anyone can build against - the iOS app is one client, your own scripts can be another
+- A clean ingest API anyone can build against - the iOS app is one client, Garmin Connect exports are another via [`scripts/import_garmin.py`](scripts/import_garmin.py)
 - Drop-in examples for piping selected metrics into Home Assistant for automations
 
 The entire stack runs in Docker on a laptop, a NUC, a Mac mini, a Synology, or a beefy workstation - your choice. Nothing phones home.
@@ -287,6 +287,45 @@ sum by (metric) (rate(hdh_ingest_rows_total[5m]))
 
 Pair `rate(hdh_ai_briefing_runs_total{result="failure"}[1h])` with an
 alert if you want a heads-up when nightly analysis starts failing.
+
+### Garmin Imports
+
+Garmin Connect users can sideload data into the same `/api/apple/batch`
+endpoint via `scripts/import_garmin.py`. The script supports the bulk
+"Export Your Data" ZIP, individual FIT/TCX activity files, and the
+JSON files Garmin includes for daily steps and sleep stages.
+
+Install the optional FIT-parsing dependency once:
+
+```bash
+pip install -e ".[garmin]"   # adds fitparse for FIT activity files
+```
+
+(TCX, JSON, and ZIP parsing use only the standard library.)
+
+Run it:
+
+```bash
+# Bulk export ZIP - walks every supported file inside
+python scripts/import_garmin.py \
+  --zip GarminConnect_Export.zip \
+  --server http://localhost:8000 \
+  --api-key $HDH_API_KEY
+
+# Individual files
+python scripts/import_garmin.py --tcx run.tcx --steps-json steps.json --sleep-json sleep.json
+
+# Sanity-check the payload before sending
+python scripts/import_garmin.py --tcx run.tcx --dry-run
+```
+
+Mapping:
+
+| Source | HealthSave metric | Server table |
+|--------|-------------------|--------------|
+| FIT/TCX heart-rate records | `heart_rate` | `heart_rate` |
+| Daily step totals (JSON) | `step_count` | `daily_activity.steps` |
+| Sleep stages (JSON) | `sleep_analysis` | `sleep_sessions` + `sleep_stages` |
 
 ### Grafana Dashboards
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,10 @@ dev = [
     "pytest==9.0.2",
     "pytest-asyncio==1.3.0",
     "ruff==0.15.9",
+    "fitparse>=1.2.0",
+]
+garmin = [
+    "fitparse>=1.2.0",
 ]
 
 [tool.setuptools.packages.find]

--- a/scripts/import_garmin.py
+++ b/scripts/import_garmin.py
@@ -1,0 +1,383 @@
+"""Import Garmin Connect exports into Health Data Hub.
+
+Reads Garmin Connect "Export Your Data" archives (or individual files) and
+POSTs the contents to ``/api/apple/batch`` using the same payload shape the
+HealthSave iOS app uses. The server handles the rest.
+
+Supported inputs (any combination):
+
+    --zip <path>          Garmin Connect bulk export ZIP
+    --fit <path>          Single FIT activity file (heart rate)
+    --tcx <path>          Single TCX activity file (heart rate)
+    --steps-json <path>   JSON file with daily step totals
+    --sleep-json <path>   JSON file with sleep stages
+
+Mapping:
+
+    FIT/TCX heart-rate records  -> metric: "heart_rate"
+    Daily step totals (JSON)    -> metric: "step_count"
+    Sleep stages (JSON)         -> metric: "sleep_analysis"
+
+FIT parsing requires the ``garmin`` extra::
+
+    pip install -e ".[garmin]"
+
+TCX, JSON, and ZIP handling use only the standard library.
+
+Examples::
+
+    python scripts/import_garmin.py --zip GarminConnect_Export.zip \\
+        --server http://localhost:8000 --api-key $HDH_API_KEY
+
+    python scripts/import_garmin.py --tcx run.tcx --dry-run
+
+    python scripts/import_garmin.py --steps-json steps.json --sleep-json sleep.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import logging
+import os
+import re
+import sys
+import zipfile
+from collections.abc import Callable, Iterable, Iterator
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import IO, Any
+from xml.etree import ElementTree as ET
+
+import httpx
+
+log = logging.getLogger("import_garmin")
+
+TCX_NS = {"tcx": "http://www.garmin.com/xmlschemas/TrainingCenterDatabase/v2"}
+
+# Garmin sleepLevels.activityLevel -> HealthSave sleep stage name.
+# 0 = deep, 1 = light, 2 = REM, 3 = awake. The server treats "core" / "light"
+# / "asleep" identically, so we standardise on the HealthSave-canonical names.
+GARMIN_SLEEP_LEVEL_TO_STAGE: dict[float, str] = {
+    0.0: "deep",
+    1.0: "light",
+    2.0: "rem",
+    3.0: "awake",
+}
+
+
+@dataclass
+class Sample:
+    metric: str
+    payload: dict[str, Any]
+
+
+@dataclass
+class ParseResult:
+    samples: list[Sample] = field(default_factory=list)
+
+    def extend(self, more: Iterable[Sample]) -> None:
+        self.samples.extend(more)
+
+
+def _iso(ts: datetime) -> str:
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=UTC)
+    return ts.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _ms_to_iso(ms: float) -> str:
+    return _iso(datetime.fromtimestamp(ms / 1000.0, tz=UTC))
+
+
+def parse_tcx(text: str, source: str = "Garmin") -> Iterator[Sample]:
+    """Yield heart-rate samples from a TCX document."""
+    root = ET.fromstring(text)
+    for trackpoint in root.iter(f"{{{TCX_NS['tcx']}}}Trackpoint"):
+        time_el = trackpoint.find("tcx:Time", TCX_NS)
+        hr_el = trackpoint.find("tcx:HeartRateBpm/tcx:Value", TCX_NS)
+        if time_el is None or hr_el is None or not (time_el.text and hr_el.text):
+            continue
+        try:
+            bpm = int(hr_el.text)
+        except ValueError:
+            continue
+        yield Sample(
+            metric="heart_rate",
+            payload={
+                "date": _normalise_iso(time_el.text),
+                "qty": bpm,
+                "unit": "count/min",
+                "source": source,
+            },
+        )
+
+
+def parse_fit(stream: IO[bytes], source: str = "Garmin") -> Iterator[Sample]:
+    """Yield heart-rate samples from a FIT activity stream.
+
+    Requires the optional ``garmin`` extra (``fitparse``).
+    """
+    try:
+        from fitparse import FitFile
+    except ImportError as exc:
+        raise ImportError(
+            "FIT parsing requires the 'garmin' extra: pip install -e \".[garmin]\""
+        ) from exc
+
+    fit = FitFile(stream)
+    for record in fit.get_messages("record"):
+        values = {field.name: field.value for field in record}
+        ts = values.get("timestamp")
+        bpm = values.get("heart_rate")
+        if ts is None or bpm is None:
+            continue
+        if isinstance(ts, datetime):
+            iso = _iso(ts)
+        else:
+            continue
+        yield Sample(
+            metric="heart_rate",
+            payload={
+                "date": iso,
+                "qty": int(bpm),
+                "unit": "count/min",
+                "source": source,
+            },
+        )
+
+
+def parse_steps_json(obj: Any, source: str = "Garmin") -> Iterator[Sample]:
+    """Yield step_count samples from Garmin's daily steps JSON.
+
+    Garmin's wellness export is a list of ``{"calendarDate": "YYYY-MM-DD",
+    "totalSteps": <int>}`` entries (older exports may use ``"steps"`` or
+    nest under a wrapper). Both shapes are accepted.
+    """
+    entries = obj if isinstance(obj, list) else obj.get("dailyStepData", [])
+    for entry in entries:
+        date = entry.get("calendarDate") or entry.get("date")
+        steps = entry.get("totalSteps", entry.get("steps"))
+        if date is None or steps is None:
+            continue
+        yield Sample(
+            metric="step_count",
+            payload={
+                "date": f"{date}T00:00:00Z",
+                "qty": int(steps),
+                "unit": "count",
+                "source": source,
+            },
+        )
+
+
+def parse_sleep_json(obj: Any, source: str = "Garmin") -> Iterator[Sample]:
+    """Yield sleep_analysis samples from Garmin's sleep export.
+
+    Garmin's sleep payload has ``dailySleepDTO`` with start/end timestamps
+    and ``sleepLevels`` — a list of ``{startGMT, endGMT, activityLevel}``
+    windows. Each window becomes one HealthSave sleep stage sample.
+    Bulk exports may wrap everything in an outer list.
+    """
+    payloads = obj if isinstance(obj, list) else [obj]
+    for daily in payloads:
+        levels = daily.get("sleepLevels") or []
+        for window in levels:
+            start = window.get("startGMT") or window.get("start_gmt")
+            end = window.get("endGMT") or window.get("end_gmt")
+            level = window.get("activityLevel")
+            if start is None or end is None or level is None:
+                continue
+            stage = GARMIN_SLEEP_LEVEL_TO_STAGE.get(float(level))
+            if stage is None:
+                continue
+            yield Sample(
+                metric="sleep_analysis",
+                payload={
+                    "start_date": _normalise_iso(start),
+                    "end_date": _normalise_iso(end),
+                    "value": stage,
+                    "source": source,
+                },
+            )
+
+
+def _normalise_iso(raw: str) -> str:
+    """Coerce common timestamp formats into ``YYYY-MM-DDTHH:MM:SSZ``."""
+    raw = raw.strip()
+    # Garmin sometimes emits epoch milliseconds as a string.
+    if raw.isdigit():
+        return _ms_to_iso(float(raw))
+    # Replace "+00:00" with "Z"; accept either form on input.
+    cleaned = raw.replace("Z", "+00:00")
+    try:
+        ts = datetime.fromisoformat(cleaned)
+    except ValueError:
+        return raw
+    return _iso(ts)
+
+
+def parse_zip(path: Path, source: str = "Garmin") -> Iterator[Sample]:
+    """Walk a Garmin Connect bulk-export ZIP and dispatch each member."""
+    with zipfile.ZipFile(path) as zf:
+        for member in zf.namelist():
+            lower = member.lower()
+            if lower.endswith(".fit"):
+                with zf.open(member) as fh:
+                    yield from parse_fit(io.BytesIO(fh.read()), source=source)
+            elif lower.endswith(".tcx"):
+                with zf.open(member) as fh:
+                    yield from parse_tcx(fh.read().decode("utf-8"), source=source)
+            elif lower.endswith(".json"):
+                with zf.open(member) as fh:
+                    try:
+                        obj = json.load(fh)
+                    except json.JSONDecodeError:
+                        log.warning("skipping non-JSON file %s", member)
+                        continue
+                if "sleep" in lower:
+                    yield from parse_sleep_json(obj, source=source)
+                elif re.search(r"step|wellness|udsfile", lower):
+                    yield from parse_steps_json(obj, source=source)
+
+
+def build_batches(samples: Iterable[Sample], *, batch_size: int = 1000) -> Iterator[dict]:
+    """Group samples by metric and yield HealthSave batch payloads."""
+    buckets: dict[str, list[dict]] = {}
+    for sample in samples:
+        buckets.setdefault(sample.metric, []).append(sample.payload)
+
+    for metric, payloads in buckets.items():
+        chunks = [payloads[i : i + batch_size] for i in range(0, len(payloads), batch_size)] or [[]]
+        total = len(chunks)
+        for index, chunk in enumerate(chunks):
+            yield {
+                "metric": metric,
+                "batch_index": index,
+                "total_batches": total,
+                "samples": chunk,
+            }
+
+
+def post_batches(
+    batches: Iterable[dict],
+    *,
+    base_url: str,
+    api_key: str | None = None,
+    transport: httpx.BaseTransport | None = None,
+    timeout: float = 30.0,
+) -> tuple[int, int]:
+    """POST each batch to ``/api/apple/batch``. Returns ``(batches, records)``."""
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["x-api-key"] = api_key
+
+    sent_batches = 0
+    sent_records = 0
+    with httpx.Client(transport=transport, timeout=timeout) as client:
+        for batch in batches:
+            response = client.post(
+                f"{base_url.rstrip('/')}/api/apple/batch",
+                json=batch,
+                headers=headers,
+            )
+            response.raise_for_status()
+            sent_batches += 1
+            sent_records += len(batch["samples"])
+    return sent_batches, sent_records
+
+
+def collect_samples(args: argparse.Namespace) -> list[Sample]:
+    result = ParseResult()
+    if args.zip:
+        result.extend(parse_zip(Path(args.zip), source=args.source))
+    if args.fit:
+        with open(args.fit, "rb") as fh:
+            result.extend(parse_fit(fh, source=args.source))
+    if args.tcx:
+        result.extend(parse_tcx(Path(args.tcx).read_text(encoding="utf-8"), source=args.source))
+    if args.steps_json:
+        result.extend(
+            parse_steps_json(json.loads(Path(args.steps_json).read_text()), source=args.source)
+        )
+    if args.sleep_json:
+        result.extend(
+            parse_sleep_json(json.loads(Path(args.sleep_json).read_text()), source=args.source)
+        )
+    return result.samples
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="import_garmin",
+        description="Import Garmin Connect exports into Health Data Hub.",
+    )
+    parser.add_argument("--zip", help="Garmin Connect bulk export ZIP")
+    parser.add_argument("--fit", help="Single FIT activity file (heart rate)")
+    parser.add_argument("--tcx", help="Single TCX activity file (heart rate)")
+    parser.add_argument("--steps-json", help="JSON file of daily step totals")
+    parser.add_argument("--sleep-json", help="JSON file of sleep stages")
+    parser.add_argument(
+        "--server",
+        default=os.environ.get("HDH_SERVER", "http://localhost:8000"),
+        help="Health Data Hub base URL (default: http://localhost:8000)",
+    )
+    parser.add_argument(
+        "--api-key",
+        default=os.environ.get("HDH_API_KEY"),
+        help="Optional x-api-key header value",
+    )
+    parser.add_argument(
+        "--source",
+        default="Garmin",
+        help="device_type label for ingested samples (default: Garmin)",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=1000,
+        help="Samples per HTTP batch (default: 1000)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print batches as JSON to stdout instead of POSTing",
+    )
+    return parser
+
+
+def main(
+    argv: list[str] | None = None,
+    *,
+    poster: Callable[..., tuple[int, int]] | None = None,
+    out: IO[str] | None = None,
+) -> int:
+    args = build_arg_parser().parse_args(argv)
+    if not (args.zip or args.fit or args.tcx or args.steps_json or args.sleep_json):
+        sys.stderr.write("at least one input flag is required\n")
+        return 2
+
+    samples = collect_samples(args)
+    batches = list(build_batches(samples, batch_size=args.batch_size))
+
+    if args.dry_run:
+        sink = out or sys.stdout
+        json.dump(batches, sink, indent=2, default=str)
+        sink.write("\n")
+        return 0
+
+    sender = poster or post_batches
+    sent_batches, sent_records = sender(
+        batches,
+        base_url=args.server,
+        api_key=args.api_key,
+    )
+    log.info("posted %d batches (%d records) to %s", sent_batches, sent_records, args.server)
+    return 0
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    raise SystemExit(main())

--- a/tests/fixtures/garmin/README.md
+++ b/tests/fixtures/garmin/README.md
@@ -1,0 +1,16 @@
+# Garmin import fixtures
+
+All files in this directory are **synthetic** — fabricated heart-rate
+values, step totals, and sleep stage windows that resemble Garmin Connect
+exports without containing real user data. Timestamps are 2026-dated to
+avoid collisions with any real activity in test databases.
+
+| File | Format | Coverage |
+|------|--------|----------|
+| `sample.tcx` | TCX 1.0 (Garmin namespace) | 6 trackpoints, heart_rate field |
+| `sample_steps.json` | Garmin wellness daily-steps JSON | 7 days of `{calendarDate, totalSteps}` |
+| `sample_sleep.json` | Garmin sleep export with `sleepLevels` | One night, 8 stage windows |
+
+FIT parsing is exercised in `tests/test_import_garmin.py` via a mocked
+`fitparse.FitFile` rather than a binary fixture, since synthesizing a
+valid FIT file is non-trivial and the parser logic is straightforward.

--- a/tests/fixtures/garmin/sample.tcx
+++ b/tests/fixtures/garmin/sample.tcx
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Synthetic Garmin TCX fixture. All timestamps and heart-rate values are fabricated. -->
+<TrainingCenterDatabase xmlns="http://www.garmin.com/xmlschemas/TrainingCenterDatabase/v2">
+  <Activities>
+    <Activity Sport="Running">
+      <Id>2026-04-10T07:00:00Z</Id>
+      <Lap StartTime="2026-04-10T07:00:00Z">
+        <Track>
+          <Trackpoint>
+            <Time>2026-04-10T07:00:00Z</Time>
+            <HeartRateBpm><Value>78</Value></HeartRateBpm>
+          </Trackpoint>
+          <Trackpoint>
+            <Time>2026-04-10T07:00:10Z</Time>
+            <HeartRateBpm><Value>92</Value></HeartRateBpm>
+          </Trackpoint>
+          <Trackpoint>
+            <Time>2026-04-10T07:00:20Z</Time>
+            <HeartRateBpm><Value>118</Value></HeartRateBpm>
+          </Trackpoint>
+          <Trackpoint>
+            <Time>2026-04-10T07:00:30Z</Time>
+            <HeartRateBpm><Value>134</Value></HeartRateBpm>
+          </Trackpoint>
+          <Trackpoint>
+            <Time>2026-04-10T07:00:40Z</Time>
+            <HeartRateBpm><Value>141</Value></HeartRateBpm>
+          </Trackpoint>
+          <Trackpoint>
+            <Time>2026-04-10T07:00:50Z</Time>
+            <HeartRateBpm><Value>146</Value></HeartRateBpm>
+          </Trackpoint>
+        </Track>
+      </Lap>
+    </Activity>
+  </Activities>
+</TrainingCenterDatabase>

--- a/tests/fixtures/garmin/sample_sleep.json
+++ b/tests/fixtures/garmin/sample_sleep.json
@@ -1,0 +1,17 @@
+{
+  "dailySleepDTO": {
+    "calendarDate": "2026-04-09",
+    "sleepStartTimestampGMT": "2026-04-09T22:00:00Z",
+    "sleepEndTimestampGMT": "2026-04-10T06:00:00Z"
+  },
+  "sleepLevels": [
+    {"startGMT": "2026-04-09T22:00:00Z", "endGMT": "2026-04-09T22:45:00Z", "activityLevel": 1.0},
+    {"startGMT": "2026-04-09T22:45:00Z", "endGMT": "2026-04-09T23:30:00Z", "activityLevel": 0.0},
+    {"startGMT": "2026-04-09T23:30:00Z", "endGMT": "2026-04-10T00:15:00Z", "activityLevel": 1.0},
+    {"startGMT": "2026-04-10T00:15:00Z", "endGMT": "2026-04-10T01:30:00Z", "activityLevel": 2.0},
+    {"startGMT": "2026-04-10T01:30:00Z", "endGMT": "2026-04-10T02:00:00Z", "activityLevel": 0.0},
+    {"startGMT": "2026-04-10T02:00:00Z", "endGMT": "2026-04-10T05:30:00Z", "activityLevel": 1.0},
+    {"startGMT": "2026-04-10T05:30:00Z", "endGMT": "2026-04-10T05:45:00Z", "activityLevel": 3.0},
+    {"startGMT": "2026-04-10T05:45:00Z", "endGMT": "2026-04-10T06:00:00Z", "activityLevel": 1.0}
+  ]
+}

--- a/tests/fixtures/garmin/sample_steps.json
+++ b/tests/fixtures/garmin/sample_steps.json
@@ -1,0 +1,9 @@
+[
+  {"calendarDate": "2026-04-04", "totalSteps": 8421},
+  {"calendarDate": "2026-04-05", "totalSteps": 11203},
+  {"calendarDate": "2026-04-06", "totalSteps": 9510},
+  {"calendarDate": "2026-04-07", "totalSteps": 7842},
+  {"calendarDate": "2026-04-08", "totalSteps": 12087},
+  {"calendarDate": "2026-04-09", "totalSteps": 6975},
+  {"calendarDate": "2026-04-10", "totalSteps": 10450}
+]

--- a/tests/test_import_garmin.py
+++ b/tests/test_import_garmin.py
@@ -1,0 +1,291 @@
+"""Tests for ``scripts/import_garmin.py``."""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+sys.path.insert(0, str(ROOT))
+
+import import_garmin  # noqa: E402
+
+FIXTURES = Path(__file__).parent / "fixtures" / "garmin"
+
+
+def _samples_for(metric: str, samples):
+    return [s for s in samples if s.metric == metric]
+
+
+def test_parse_tcx_yields_heart_rate_samples_with_iso_timestamps():
+    text = (FIXTURES / "sample.tcx").read_text(encoding="utf-8")
+    samples = list(import_garmin.parse_tcx(text, source="Garmin"))
+
+    assert len(samples) == 6
+    assert all(s.metric == "heart_rate" for s in samples)
+    first = samples[0].payload
+    assert first["date"] == "2026-04-10T07:00:00Z"
+    assert first["qty"] == 78
+    assert first["unit"] == "count/min"
+    assert first["source"] == "Garmin"
+    assert [s.payload["qty"] for s in samples] == [78, 92, 118, 134, 141, 146]
+
+
+def test_parse_steps_json_yields_one_sample_per_day():
+    obj = json.loads((FIXTURES / "sample_steps.json").read_text())
+    samples = list(import_garmin.parse_steps_json(obj))
+
+    assert len(samples) == 7
+    assert all(s.metric == "step_count" for s in samples)
+    first = samples[0].payload
+    assert first["date"] == "2026-04-04T00:00:00Z"
+    assert first["qty"] == 8421
+    assert first["unit"] == "count"
+    assert first["source"] == "Garmin"
+
+
+def test_parse_sleep_json_maps_activity_levels_to_canonical_stages():
+    obj = json.loads((FIXTURES / "sample_sleep.json").read_text())
+    samples = list(import_garmin.parse_sleep_json(obj))
+
+    assert len(samples) == 8
+    assert all(s.metric == "sleep_analysis" for s in samples)
+    stages = [s.payload["value"] for s in samples]
+    assert stages == ["light", "deep", "light", "rem", "deep", "light", "awake", "light"]
+
+    first = samples[0].payload
+    assert first["start_date"] == "2026-04-09T22:00:00Z"
+    assert first["end_date"] == "2026-04-09T22:45:00Z"
+    assert first["source"] == "Garmin"
+
+
+def test_parse_sleep_json_skips_unknown_activity_level():
+    obj = {
+        "sleepLevels": [
+            {
+                "startGMT": "2026-04-10T00:00:00Z",
+                "endGMT": "2026-04-10T01:00:00Z",
+                "activityLevel": 99,
+            }
+        ]
+    }
+    assert list(import_garmin.parse_sleep_json(obj)) == []
+
+
+def test_parse_fit_translates_record_messages_to_heart_rate_samples():
+    """FIT parsing is exercised via a mock FitFile to avoid bundling a binary fixture."""
+
+    class FakeField:
+        def __init__(self, name, value):
+            self.name = name
+            self.value = value
+
+    class FakeRecord:
+        def __init__(self, fields):
+            self._fields = fields
+
+        def __iter__(self):
+            return iter(self._fields)
+
+    class FakeFitFile:
+        def __init__(self, _stream):
+            pass
+
+        def get_messages(self, name):
+            assert name == "record"
+            return [
+                FakeRecord(
+                    [
+                        FakeField("timestamp", datetime(2026, 4, 10, 7, 0, 0, tzinfo=UTC)),
+                        FakeField("heart_rate", 110),
+                    ]
+                ),
+                # Records without heart_rate are skipped.
+                FakeRecord([FakeField("timestamp", datetime(2026, 4, 10, 7, 0, 1, tzinfo=UTC))]),
+                FakeRecord(
+                    [
+                        FakeField("timestamp", datetime(2026, 4, 10, 7, 0, 2, tzinfo=UTC)),
+                        FakeField("heart_rate", 115),
+                    ]
+                ),
+            ]
+
+    with patch.dict("sys.modules", {"fitparse": type("M", (), {"FitFile": FakeFitFile})()}):
+        samples = list(import_garmin.parse_fit(io.BytesIO(b""), source="Garmin Forerunner"))
+
+    assert [s.payload["qty"] for s in samples] == [110, 115]
+    assert samples[0].payload["date"] == "2026-04-10T07:00:00Z"
+    assert samples[0].payload["source"] == "Garmin Forerunner"
+
+
+def test_build_batches_groups_by_metric_and_chunks():
+    samples = [
+        import_garmin.Sample("heart_rate", {"date": "2026-04-10T00:00:00Z", "qty": 70}),
+        import_garmin.Sample("heart_rate", {"date": "2026-04-10T00:00:01Z", "qty": 71}),
+        import_garmin.Sample("heart_rate", {"date": "2026-04-10T00:00:02Z", "qty": 72}),
+        import_garmin.Sample("step_count", {"date": "2026-04-10T00:00:00Z", "qty": 9000}),
+    ]
+    batches = list(import_garmin.build_batches(samples, batch_size=2))
+
+    by_metric = {}
+    for batch in batches:
+        by_metric.setdefault(batch["metric"], []).append(batch)
+
+    hr_batches = by_metric["heart_rate"]
+    assert len(hr_batches) == 2
+    assert hr_batches[0]["batch_index"] == 0
+    assert hr_batches[0]["total_batches"] == 2
+    assert len(hr_batches[0]["samples"]) == 2
+    assert len(hr_batches[1]["samples"]) == 1
+
+    steps_batches = by_metric["step_count"]
+    assert len(steps_batches) == 1
+    assert steps_batches[0]["total_batches"] == 1
+
+
+def test_post_batches_sends_correct_payload_and_headers_with_mock_transport():
+    captured = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(
+            {
+                "url": str(request.url),
+                "headers": {k: v for k, v in request.headers.items()},
+                "body": json.loads(request.content.decode()),
+            }
+        )
+        return httpx.Response(200, json={"status": "processed", "records": 1})
+
+    transport = httpx.MockTransport(handler)
+    batches = [
+        {
+            "metric": "heart_rate",
+            "batch_index": 0,
+            "total_batches": 1,
+            "samples": [{"date": "2026-04-10T00:00:00Z", "qty": 70}],
+        }
+    ]
+
+    sent_batches, sent_records = import_garmin.post_batches(
+        batches,
+        base_url="http://hub.example",
+        api_key="secret-key",
+        transport=transport,
+    )
+
+    assert sent_batches == 1
+    assert sent_records == 1
+    assert captured[0]["url"] == "http://hub.example/api/apple/batch"
+    assert captured[0]["headers"]["x-api-key"] == "secret-key"
+    assert captured[0]["body"]["metric"] == "heart_rate"
+
+
+def test_main_dry_run_writes_batches_to_stdout(tmp_path):
+    out = io.StringIO()
+    exit_code = import_garmin.main(
+        argv=[
+            "--tcx",
+            str(FIXTURES / "sample.tcx"),
+            "--steps-json",
+            str(FIXTURES / "sample_steps.json"),
+            "--dry-run",
+        ],
+        out=out,
+    )
+    assert exit_code == 0
+
+    payload = json.loads(out.getvalue())
+    metrics = sorted({batch["metric"] for batch in payload})
+    assert metrics == ["heart_rate", "step_count"]
+    total_records = sum(len(batch["samples"]) for batch in payload)
+    assert total_records == 6 + 7  # tcx trackpoints + step days
+
+
+def test_main_requires_at_least_one_input(capsys):
+    exit_code = import_garmin.main(argv=["--server", "http://example"])
+    assert exit_code == 2
+    err = capsys.readouterr().err
+    assert "input flag is required" in err
+
+
+def test_main_calls_poster_when_not_dry_run():
+    calls = []
+
+    def fake_poster(batches, *, base_url, api_key):
+        batches = list(batches)
+        calls.append({"count": len(batches), "base_url": base_url, "api_key": api_key})
+        return len(batches), sum(len(b["samples"]) for b in batches)
+
+    exit_code = import_garmin.main(
+        argv=[
+            "--steps-json",
+            str(FIXTURES / "sample_steps.json"),
+            "--server",
+            "http://hub.example",
+            "--api-key",
+            "k",
+        ],
+        poster=fake_poster,
+    )
+
+    assert exit_code == 0
+    assert calls == [{"count": 1, "base_url": "http://hub.example", "api_key": "k"}]
+
+
+def test_parse_zip_dispatches_per_file_extension(tmp_path):
+    import zipfile
+
+    zip_path = tmp_path / "garmin.zip"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.writestr("DI_CONNECT/DI-Connect-Fitness/run.tcx", (FIXTURES / "sample.tcx").read_text())
+        zf.writestr(
+            "DI_CONNECT/DI-Connect-Wellness/UDS_steps_2026.json",
+            (FIXTURES / "sample_steps.json").read_text(),
+        )
+        zf.writestr(
+            "DI_CONNECT/DI-Connect-Wellness/sleepData_2026.json",
+            (FIXTURES / "sample_sleep.json").read_text(),
+        )
+
+    samples = list(import_garmin.parse_zip(zip_path))
+
+    metrics = {s.metric for s in samples}
+    assert metrics == {"heart_rate", "step_count", "sleep_analysis"}
+    assert len(_samples_for("heart_rate", samples)) == 6
+    assert len(_samples_for("step_count", samples)) == 7
+    assert len(_samples_for("sleep_analysis", samples)) == 8
+
+
+def test_sleep_samples_round_trip_through_existing_sleep_aggregator():
+    """Ensure the shape we emit is what ``server.ingestion.sleep`` consumes."""
+    from server.ingestion.sleep import sleep_session_rows
+
+    obj = json.loads((FIXTURES / "sample_sleep.json").read_text())
+    samples = [s.payload for s in import_garmin.parse_sleep_json(obj)]
+    sessions = sleep_session_rows(device_id=1, samples=samples)
+
+    # One night -> one session row with non-zero deep/rem/light durations.
+    assert len(sessions) == 1
+    assert sessions[0]["deep"] > 0
+    assert sessions[0]["rem"] > 0
+    assert sessions[0]["light"] > 0
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("2026-04-10T07:00:00Z", "2026-04-10T07:00:00Z"),
+        ("2026-04-10T07:00:00+00:00", "2026-04-10T07:00:00Z"),
+        ("1776384000000", "2026-04-17T00:00:00Z"),
+    ],
+)
+def test_normalise_iso_handles_common_formats(raw, expected):
+    assert import_garmin._normalise_iso(raw) == expected


### PR DESCRIPTION
Closes #3

## What's included

- New `scripts/import_garmin.py` — CLI + importable module that ingests Garmin Connect exports into `/api/apple/batch`. Supports the bulk "Export Your Data" ZIP, individual FIT/TCX activity files, and the JSON payloads Garmin produces for daily steps and sleep stages.
- New `[garmin]` optional-dependencies group adding `fitparse>=1.2.0`. Not a baseline runtime dep — the API server itself never parses FIT files. Install via `pip install -e \".[garmin]\"`.
- `tests/fixtures/garmin/` — synthetic, 2026-dated TCX (6 trackpoints), daily-steps JSON (7 days), and sleep JSON (8 stage windows) plus a fixtures README documenting their shape.
- `tests/test_import_garmin.py` — 15 tests covering parser correctness, batch chunking, mocked POST via `httpx.MockTransport`, `--dry-run` end-to-end, missing-input argv handling, ZIP dispatch, FIT mock, and a sleep round-trip through the existing `server.ingestion.sleep.sleep_session_rows` aggregator.
- README updated in two places: top-level positioning mentions Garmin alongside HealthSave; new "Garmin Imports" subsection under "For developers" with mapping table and example invocations.

## Mapping

| Source | HealthSave metric | Server table |
|--------|-------------------|--------------|
| FIT/TCX heart-rate records | `heart_rate` | `heart_rate` |
| Daily step totals (JSON) | `step_count` | `daily_activity.steps` |
| Sleep stage windows (JSON) | `sleep_analysis` | `sleep_sessions` + `sleep_stages` |

## Acceptance criteria checklist

- [x] Documented script in `scripts/import_garmin.py` (module docstring + per-function docstrings + README section)
- [x] Sample anonymised data files in `tests/fixtures/garmin/` — fully synthetic, 2026-dated
- [x] Unit test covering at least heart rate + steps + sleep mapping (15 tests, all three covered plus end-to-end)
- [x] README mentions Garmin alongside HealthSave as ingest paths

## Notes / design choices

- TCX, JSON, and ZIP parsing use only the standard library. `fitparse` is **only** needed if you intend to import binary `.fit` activity files, which is why it sits under a `[garmin]` extra.
- Sleep-stage payload deliberately passes through the existing `sleep_session_rows` aggregator unchanged — a dedicated round-trip test confirms a valid session is emitted on the synthetic fixture, so this PR adds no new server-side logic.
- ZIP dispatch globs by extension and filename hint (`*sleep*.json`, `*step*|*wellness*|*udsfile*.json`) instead of hard-coding Garmin's path layout, which has drifted across export versions.
- HTTP layer uses `httpx` (already a transitive dep via `litellm`) so tests can use `httpx.MockTransport` to assert payload shape without sockets.
- `main()` accepts an injected `poster` callable for testability — no live server needed in CI.

## Quality gates

- `ruff format --check .` clean
- `ruff check .` clean
- `pytest -q` — 104 passed (15 new + 89 existing)