### PR TITLE
feat(multi-user): X-User-Id ingest header + owner_id schema column

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,7 +350,29 @@ their original schema, so apply migrations manually when upgrading:
 ```bash
 docker compose exec -T db psql -U healthsave -d healthsave < migrations/001_audit_hardening.sql
 docker compose exec -T db psql -U healthsave -d healthsave < migrations/002_analysis_tables.sql
+docker compose exec -T db psql -U healthsave -d healthsave < migrations/003_multi_user.sql
 ```
+
+### Multi-user / Household
+
+Every metric table carries an `owner_id` UUID. Single-user installs need
+to do nothing — when the `X-User-Id` header is absent, ingest writes
+under the sentinel UUID `00000000-0000-0000-0000-000000000001` and the
+schema-level default backfills any pre-migration rows to the same value.
+
+To split a household across multiple residents:
+
+1. Pick a UUID per person (any v4 UUID works — `python -c "import uuid; print(uuid.uuid4())"`).
+2. Configure each HealthSave client / import script to send that UUID as the
+   `X-User-Id` header on every `POST /api/apple/batch` call.
+3. Filter Grafana panels by `owner_id` (add a dashboard variable bound to the
+   `SELECT DISTINCT owner_id FROM heart_rate` query, then drop `WHERE owner_id = '$owner'`
+   into each panel query).
+
+Existing single-user installs keep working untouched if step 2 is skipped.
+The unique indexes on every metric table include `owner_id`, so two
+residents can have a sample at the same `(time, device_id)` without
+collisions, and re-syncing from one client remains idempotent.
 
 ### Development
 

--- a/migrations/003_multi_user.sql
+++ b/migrations/003_multi_user.sql
@@ -1,0 +1,100 @@
+-- 003_multi_user.sql
+--
+-- Multi-user / household support: add an owner_id UUID column to every
+-- metric table so multiple residents can ingest into the same stack.
+--
+-- Backward-compatible by construction:
+--   * owner_id is NOT NULL with a default of the single-user sentinel
+--     '00000000-0000-0000-0000-000000000001'. Existing rows are
+--     populated with that sentinel automatically.
+--   * Ingest paths default to the same sentinel when the X-User-Id
+--     header is absent, so existing single-user installs keep working
+--     without any client change.
+--   * Unique indexes and primary keys are widened to include owner_id
+--     so two residents can have a sample at the same (time, device_id)
+--     without colliding.
+
+BEGIN;
+
+-- Heart rate
+ALTER TABLE heart_rate
+    ADD COLUMN IF NOT EXISTS owner_id UUID NOT NULL
+    DEFAULT '00000000-0000-0000-0000-000000000001';
+DROP INDEX IF EXISTS uq_heart_rate;
+CREATE UNIQUE INDEX uq_heart_rate ON heart_rate (time, device_id, owner_id);
+
+-- HRV
+ALTER TABLE hrv
+    ADD COLUMN IF NOT EXISTS owner_id UUID NOT NULL
+    DEFAULT '00000000-0000-0000-0000-000000000001';
+DROP INDEX IF EXISTS uq_hrv;
+CREATE UNIQUE INDEX uq_hrv ON hrv (time, device_id, owner_id);
+
+-- Blood oxygen
+ALTER TABLE blood_oxygen
+    ADD COLUMN IF NOT EXISTS owner_id UUID NOT NULL
+    DEFAULT '00000000-0000-0000-0000-000000000001';
+DROP INDEX IF EXISTS uq_blood_oxygen;
+CREATE UNIQUE INDEX uq_blood_oxygen ON blood_oxygen (time, device_id, owner_id);
+
+-- Body temperature
+ALTER TABLE body_temperature
+    ADD COLUMN IF NOT EXISTS owner_id UUID NOT NULL
+    DEFAULT '00000000-0000-0000-0000-000000000001';
+DROP INDEX IF EXISTS uq_body_temperature;
+CREATE UNIQUE INDEX uq_body_temperature ON body_temperature (time, device_id, owner_id);
+
+-- Daily activity (had a primary key, not a unique index)
+ALTER TABLE daily_activity
+    ADD COLUMN IF NOT EXISTS owner_id UUID NOT NULL
+    DEFAULT '00000000-0000-0000-0000-000000000001';
+ALTER TABLE daily_activity DROP CONSTRAINT IF EXISTS daily_activity_pkey;
+ALTER TABLE daily_activity ADD PRIMARY KEY (date, device_id, owner_id);
+
+-- Sleep sessions
+ALTER TABLE sleep_sessions
+    ADD COLUMN IF NOT EXISTS owner_id UUID NOT NULL
+    DEFAULT '00000000-0000-0000-0000-000000000001';
+DROP INDEX IF EXISTS uq_sleep_sessions_device_start;
+CREATE UNIQUE INDEX uq_sleep_sessions_device_start
+    ON sleep_sessions (device_id, start_time, owner_id);
+
+-- Sleep stages
+ALTER TABLE sleep_stages
+    ADD COLUMN IF NOT EXISTS owner_id UUID NOT NULL
+    DEFAULT '00000000-0000-0000-0000-000000000001';
+DROP INDEX IF EXISTS uq_sleep_stages;
+CREATE UNIQUE INDEX uq_sleep_stages ON sleep_stages (time, device_id, stage, owner_id);
+
+-- Workouts
+ALTER TABLE workouts
+    ADD COLUMN IF NOT EXISTS owner_id UUID NOT NULL
+    DEFAULT '00000000-0000-0000-0000-000000000001';
+DROP INDEX IF EXISTS uq_workouts_device_start;
+CREATE UNIQUE INDEX uq_workouts_device_start
+    ON workouts (device_id, start_time, owner_id);
+
+-- Recovery
+ALTER TABLE recovery
+    ADD COLUMN IF NOT EXISTS owner_id UUID NOT NULL
+    DEFAULT '00000000-0000-0000-0000-000000000001';
+DROP INDEX IF EXISTS uq_recovery;
+CREATE UNIQUE INDEX uq_recovery ON recovery (time, device_id, owner_id);
+
+-- Stress
+ALTER TABLE stress
+    ADD COLUMN IF NOT EXISTS owner_id UUID NOT NULL
+    DEFAULT '00000000-0000-0000-0000-000000000001';
+DROP INDEX IF EXISTS uq_stress;
+CREATE UNIQUE INDEX uq_stress ON stress (time, device_id, owner_id);
+
+-- Quantity samples (catch-all). The original schema declared a PRIMARY KEY
+-- on (time, device_id, metric_name); widen it to include owner_id.
+ALTER TABLE quantity_samples
+    ADD COLUMN IF NOT EXISTS owner_id UUID NOT NULL
+    DEFAULT '00000000-0000-0000-0000-000000000001';
+ALTER TABLE quantity_samples DROP CONSTRAINT IF EXISTS quantity_samples_pkey;
+ALTER TABLE quantity_samples
+    ADD PRIMARY KEY (time, device_id, metric_name, owner_id);
+
+COMMIT;

--- a/schema.sql
+++ b/schema.sql
@@ -17,10 +17,11 @@ CREATE TABLE heart_rate (
     device_id   INT REFERENCES devices(id),
     source_id   TEXT,
     bpm         SMALLINT NOT NULL,
-    context     TEXT
+    context     TEXT,
+    owner_id    UUID NOT NULL DEFAULT '00000000-0000-0000-0000-000000000001'
 );
 SELECT create_hypertable('heart_rate', 'time');
-CREATE UNIQUE INDEX uq_heart_rate ON heart_rate (time, device_id);
+CREATE UNIQUE INDEX uq_heart_rate ON heart_rate (time, device_id, owner_id);
 
 -- ─── HRV ─────────────────────────────────────────────────────────────
 CREATE TABLE hrv (
@@ -29,30 +30,33 @@ CREATE TABLE hrv (
     source_id   TEXT,
     value_ms    FLOAT NOT NULL,
     algorithm   TEXT NOT NULL DEFAULT 'sdnn',
-    context     TEXT
+    context     TEXT,
+    owner_id    UUID NOT NULL DEFAULT '00000000-0000-0000-0000-000000000001'
 );
 SELECT create_hypertable('hrv', 'time');
-CREATE UNIQUE INDEX uq_hrv ON hrv (time, device_id);
+CREATE UNIQUE INDEX uq_hrv ON hrv (time, device_id, owner_id);
 
 -- ─── Blood Oxygen ────────────────────────────────────────────────────
 CREATE TABLE blood_oxygen (
     time        TIMESTAMPTZ NOT NULL,
     device_id   INT REFERENCES devices(id),
     spo2_pct    FLOAT NOT NULL,
-    context     TEXT
+    context     TEXT,
+    owner_id    UUID NOT NULL DEFAULT '00000000-0000-0000-0000-000000000001'
 );
 SELECT create_hypertable('blood_oxygen', 'time');
-CREATE UNIQUE INDEX uq_blood_oxygen ON blood_oxygen (time, device_id);
+CREATE UNIQUE INDEX uq_blood_oxygen ON blood_oxygen (time, device_id, owner_id);
 
 -- ─── Body Temperature ────────────────────────────────────────────────
 CREATE TABLE body_temperature (
     time            TIMESTAMPTZ NOT NULL,
     device_id       INT REFERENCES devices(id),
     temp_celsius    FLOAT NOT NULL,
-    measurement_type TEXT
+    measurement_type TEXT,
+    owner_id        UUID NOT NULL DEFAULT '00000000-0000-0000-0000-000000000001'
 );
 SELECT create_hypertable('body_temperature', 'time');
-CREATE UNIQUE INDEX uq_body_temperature ON body_temperature (time, device_id);
+CREATE UNIQUE INDEX uq_body_temperature ON body_temperature (time, device_id, owner_id);
 
 -- ─── Daily Activity ──────────────────────────────────────────────────
 CREATE TABLE daily_activity (
@@ -67,7 +71,8 @@ CREATE TABLE daily_activity (
     stand_hours     INT,
     avg_hr          FLOAT,
     max_hr          FLOAT,
-    PRIMARY KEY (date, device_id)
+    owner_id        UUID NOT NULL DEFAULT '00000000-0000-0000-0000-000000000001',
+    PRIMARY KEY (date, device_id, owner_id)
 );
 
 -- ─── Sleep Sessions ──────────────────────────────────────────────────
@@ -81,9 +86,11 @@ CREATE TABLE sleep_sessions (
     light_ms            BIGINT,
     deep_ms             BIGINT,
     rem_ms              BIGINT,
-    respiratory_rate    FLOAT
+    respiratory_rate    FLOAT,
+    owner_id            UUID NOT NULL DEFAULT '00000000-0000-0000-0000-000000000001'
 );
-CREATE UNIQUE INDEX uq_sleep_sessions_device_start ON sleep_sessions (device_id, start_time);
+CREATE UNIQUE INDEX uq_sleep_sessions_device_start
+    ON sleep_sessions (device_id, start_time, owner_id);
 
 -- ─── Sleep Stages ────────────────────────────────────────────────────
 CREATE TABLE sleep_stages (
@@ -91,10 +98,11 @@ CREATE TABLE sleep_stages (
     device_id   INT REFERENCES devices(id),
     session_id  BIGINT REFERENCES sleep_sessions(id),
     stage       TEXT NOT NULL,
-    duration_ms BIGINT
+    duration_ms BIGINT,
+    owner_id    UUID NOT NULL DEFAULT '00000000-0000-0000-0000-000000000001'
 );
 SELECT create_hypertable('sleep_stages', 'time');
-CREATE UNIQUE INDEX uq_sleep_stages ON sleep_stages (time, device_id, stage);
+CREATE UNIQUE INDEX uq_sleep_stages ON sleep_stages (time, device_id, stage, owner_id);
 
 -- ─── Workouts ────────────────────────────────────────────────────────
 CREATE TABLE workouts (
@@ -107,9 +115,11 @@ CREATE TABLE workouts (
     avg_hr          FLOAT,
     max_hr          FLOAT,
     calories        FLOAT,
-    distance_m      FLOAT
+    distance_m      FLOAT,
+    owner_id        UUID NOT NULL DEFAULT '00000000-0000-0000-0000-000000000001'
 );
-CREATE UNIQUE INDEX uq_workouts_device_start ON workouts (device_id, start_time);
+CREATE UNIQUE INDEX uq_workouts_device_start
+    ON workouts (device_id, start_time, owner_id);
 
 -- ─── Recovery / Readiness ────────────────────────────────────────────
 CREATE TABLE recovery (
@@ -119,20 +129,22 @@ CREATE TABLE recovery (
     resting_hr  FLOAT,
     hrv_ms      FLOAT,
     spo2_pct    FLOAT,
-    skin_temp_c FLOAT
+    skin_temp_c FLOAT,
+    owner_id    UUID NOT NULL DEFAULT '00000000-0000-0000-0000-000000000001'
 );
 SELECT create_hypertable('recovery', 'time');
-CREATE UNIQUE INDEX uq_recovery ON recovery (time, device_id);
+CREATE UNIQUE INDEX uq_recovery ON recovery (time, device_id, owner_id);
 
 -- ─── Stress Readings ─────────────────────────────────────────────────
 CREATE TABLE stress (
     time        TIMESTAMPTZ NOT NULL,
     device_id   INT REFERENCES devices(id),
     score       FLOAT NOT NULL,
-    scale_type  TEXT
+    scale_type  TEXT,
+    owner_id    UUID NOT NULL DEFAULT '00000000-0000-0000-0000-000000000001'
 );
 SELECT create_hypertable('stress', 'time');
-CREATE UNIQUE INDEX uq_stress ON stress (time, device_id);
+CREATE UNIQUE INDEX uq_stress ON stress (time, device_id, owner_id);
 
 -- ─── Raw Ingestion Log ───────────────────────────────────────────────
 CREATE TABLE raw_ingestion_log (
@@ -154,7 +166,8 @@ CREATE TABLE quantity_samples (
     value       DOUBLE PRECISION NOT NULL,
     unit        TEXT,
     source_id   TEXT,
-    PRIMARY KEY (time, device_id, metric_name)
+    owner_id    UUID NOT NULL DEFAULT '00000000-0000-0000-0000-000000000001',
+    PRIMARY KEY (time, device_id, metric_name, owner_id)
 );
 SELECT create_hypertable('quantity_samples', 'time', if_not_exists => TRUE);
 CREATE INDEX idx_quantity_samples_metric ON quantity_samples (metric_name, time DESC);

--- a/server/api/ingest.py
+++ b/server/api/ingest.py
@@ -13,6 +13,7 @@ from ..ingestion.handlers import (
     _log_raw_ingestion,
     _mark_raw_ingestion_processed,
 )
+from ..ingestion.owner import OWNER_HEADER, resolve_owner_id
 from ..ingestion.parsers import group_samples_by_device
 from ..models.batch import BatchPayload
 from .deps import get_session, verify_api_key
@@ -49,6 +50,11 @@ async def apple_batch(
     except ValidationError as exc:
         raise HTTPException(status_code=422, detail=exc.errors()) from exc
 
+    try:
+        owner_id = resolve_owner_id(request.headers.get(OWNER_HEADER))
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=f"invalid {OWNER_HEADER}: {exc}") from exc
+
     metric = payload.metric.strip() or "unknown"
     batch_idx = payload.batch_index
     total = payload.total_batches
@@ -75,7 +81,7 @@ async def apple_batch(
             if device_name == first_device_name
             else await _get_or_create_device(session, device_name)
         )
-        count += await _ingest_metric(session, device_id, metric, device_samples)
+        count += await _ingest_metric(session, device_id, metric, device_samples, owner_id)
 
     await _mark_raw_ingestion_processed(session, raw_log_id)
     await session.commit()

--- a/server/ingestion/handlers.py
+++ b/server/ingestion/handlers.py
@@ -8,12 +8,16 @@ writer based on the metric name, falling back to the catch-all
 so that the existing private dispatch table keeps working unchanged.
 """
 
+from __future__ import annotations
+
 from json import dumps
+from uuid import UUID
 
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from .mappers import ACTIVITY_FIELDS, DAILY_ACTIVITY_QUANTITY_FIELDS, DEDICATED_TABLES
+from .owner import DEFAULT_OWNER_ID
 from .parsers import first_present, parse_date, parse_ts, to_float, to_int
 from .sleep import ingest_sleep
 
@@ -67,29 +71,38 @@ async def _mark_raw_ingestion_processed(session: AsyncSession, raw_log_id: int |
 
 
 async def _ingest_metric(
-    session: AsyncSession, device_id: int, metric: str, samples: list[dict]
+    session: AsyncSession,
+    device_id: int,
+    metric: str,
+    samples: list[dict],
+    owner_id: UUID = DEFAULT_OWNER_ID,
 ) -> int:
     if metric == "activity_summaries":
-        return await _ingest_activity(session, device_id, samples)
+        return await _ingest_activity(session, device_id, samples, owner_id=owner_id)
     if metric in DAILY_ACTIVITY_QUANTITY_FIELDS:
-        return await _ingest_daily_quantity(session, device_id, metric, samples)
+        return await _ingest_daily_quantity(session, device_id, metric, samples, owner_id=owner_id)
     if metric == "sleep_analysis":
-        return await _ingest_sleep(session, device_id, samples)
+        return await _ingest_sleep(session, device_id, samples, owner_id=owner_id)
     if metric == "workouts":
-        return await _ingest_workouts(session, device_id, samples)
+        return await _ingest_workouts(session, device_id, samples, owner_id=owner_id)
     if metric in DEDICATED_TABLES:
-        return await _ingest_dedicated(session, device_id, metric, samples)
-    return await _ingest_generic(session, device_id, metric, samples)
+        return await _ingest_dedicated(session, device_id, metric, samples, owner_id=owner_id)
+    return await _ingest_generic(session, device_id, metric, samples, owner_id=owner_id)
 
 
 async def _ingest_dedicated(
-    session: AsyncSession, device_id: int, metric: str, samples: list
+    session: AsyncSession,
+    device_id: int,
+    metric: str,
+    samples: list,
+    *,
+    owner_id: UUID = DEFAULT_OWNER_ID,
 ) -> int:
     spec = DEDICATED_TABLES[metric]
     rows = []
     value_col = list(spec["columns"].values())[1]
     for s in samples:
-        row = {"device_id": device_id}
+        row = {"device_id": device_id, "owner_id": str(owner_id)}
         for src_key, dst_col in spec["columns"].items():
             val = s.get(src_key)
             if dst_col == "time":
@@ -105,22 +118,23 @@ async def _ingest_dedicated(
     if not rows:
         return 0
 
-    # Dedup within batch
+    # Dedup within batch (conflict_cols already include owner_id via the schema)
+    conflict_cols = list(spec["conflict"]) + ["owner_id"]
     seen = {}
     for row in rows:
-        key = tuple(row.get(c) for c in spec["conflict"])
+        key = tuple(row.get(c) for c in conflict_cols)
         seen[key] = row
     rows = list(seen.values())
 
-    conflict_cols = ", ".join(spec["conflict"])
+    conflict_sql = ", ".join(conflict_cols)
     col_names = ", ".join(rows[0].keys())
     placeholders = ", ".join(f":{k}" for k in rows[0])
-    update_set = ", ".join(f"{c} = EXCLUDED.{c}" for c in rows[0] if c not in spec["conflict"])
+    update_set = ", ".join(f"{c} = EXCLUDED.{c}" for c in rows[0] if c not in conflict_cols)
 
     sql = f"""
         INSERT INTO {spec["table"]} ({col_names})
         VALUES ({placeholders})
-        ON CONFLICT ({conflict_cols}) DO UPDATE SET {update_set}
+        ON CONFLICT ({conflict_sql}) DO UPDATE SET {update_set}
     """
 
     for row in rows:
@@ -129,7 +143,14 @@ async def _ingest_dedicated(
     return len(rows)
 
 
-async def _ingest_generic(session: AsyncSession, device_id: int, metric: str, samples: list) -> int:
+async def _ingest_generic(
+    session: AsyncSession,
+    device_id: int,
+    metric: str,
+    samples: list,
+    *,
+    owner_id: UUID = DEFAULT_OWNER_ID,
+) -> int:
     """Insert into the catch-all quantity_samples table."""
     count = 0
     for s in samples:
@@ -140,9 +161,10 @@ async def _ingest_generic(session: AsyncSession, device_id: int, metric: str, sa
         sample_metric = s.get("metric") if isinstance(s.get("metric"), str) else metric
         await session.execute(
             text("""
-                INSERT INTO quantity_samples (time, device_id, metric_name, value, unit, source_id)
-                VALUES (:time, :device_id, :metric, :value, :unit, :source)
-                ON CONFLICT (time, device_id, metric_name) DO UPDATE
+                INSERT INTO quantity_samples
+                    (time, device_id, metric_name, value, unit, source_id, owner_id)
+                VALUES (:time, :device_id, :metric, :value, :unit, :source, :owner_id)
+                ON CONFLICT (time, device_id, metric_name, owner_id) DO UPDATE
                 SET value = EXCLUDED.value, unit = EXCLUDED.unit
             """),
             {
@@ -152,20 +174,27 @@ async def _ingest_generic(session: AsyncSession, device_id: int, metric: str, sa
                 "value": v,
                 "unit": s.get("unit", ""),
                 "source": s.get("source", ""),
+                "owner_id": str(owner_id),
             },
         )
         count += 1
     return count
 
 
-async def _ingest_activity(session: AsyncSession, device_id: int, samples: list) -> int:
+async def _ingest_activity(
+    session: AsyncSession,
+    device_id: int,
+    samples: list,
+    *,
+    owner_id: UUID = DEFAULT_OWNER_ID,
+) -> int:
     count = 0
     for s in samples:
         d = parse_date(s.get("date"))
         if not d:
             continue
 
-        row = {"date": d, "device_id": device_id}
+        row = {"date": d, "device_id": device_id, "owner_id": str(owner_id)}
         for src_key, dst_col in ACTIVITY_FIELDS.items():
             if src_key in s:
                 row[dst_col] = s[src_key]
@@ -175,13 +204,13 @@ async def _ingest_activity(session: AsyncSession, device_id: int, samples: list)
         updates = ", ".join(
             f"{k} = COALESCE(EXCLUDED.{k}, daily_activity.{k})"
             for k in row
-            if k not in ("date", "device_id")
+            if k not in ("date", "device_id", "owner_id")
         )
 
         await session.execute(
             text(f"""
                 INSERT INTO daily_activity ({cols}) VALUES ({vals})
-                ON CONFLICT (date, device_id) DO UPDATE SET {updates}
+                ON CONFLICT (date, device_id, owner_id) DO UPDATE SET {updates}
             """),
             row,
         )
@@ -190,7 +219,12 @@ async def _ingest_activity(session: AsyncSession, device_id: int, samples: list)
 
 
 async def _ingest_daily_quantity(
-    session: AsyncSession, device_id: int, metric: str, samples: list
+    session: AsyncSession,
+    device_id: int,
+    metric: str,
+    samples: list,
+    *,
+    owner_id: UUID = DEFAULT_OWNER_ID,
 ) -> int:
     column, converter = DAILY_ACTIVITY_QUANTITY_FIELDS[metric]
     count = 0
@@ -202,18 +236,29 @@ async def _ingest_daily_quantity(
 
         await session.execute(
             text(f"""
-                INSERT INTO daily_activity (date, device_id, {column})
-                VALUES (:date, :device_id, :{column})
-                ON CONFLICT (date, device_id) DO UPDATE
+                INSERT INTO daily_activity (date, device_id, owner_id, {column})
+                VALUES (:date, :device_id, :owner_id, :{column})
+                ON CONFLICT (date, device_id, owner_id) DO UPDATE
                 SET {column} = EXCLUDED.{column}
             """),
-            {"date": d, "device_id": device_id, column: value},
+            {
+                "date": d,
+                "device_id": device_id,
+                "owner_id": str(owner_id),
+                column: value,
+            },
         )
         count += 1
     return count
 
 
-async def _ingest_workouts(session: AsyncSession, device_id: int, samples: list) -> int:
+async def _ingest_workouts(
+    session: AsyncSession,
+    device_id: int,
+    samples: list,
+    *,
+    owner_id: UUID = DEFAULT_OWNER_ID,
+) -> int:
     count = 0
     for s in samples:
         start = parse_ts(first_present(s, "start_date", "startDate", "start", "date"))
@@ -229,9 +274,10 @@ async def _ingest_workouts(session: AsyncSession, device_id: int, samples: list)
         await session.execute(
             text("""
                 INSERT INTO workouts (device_id, sport_type, start_time, end_time,
-                    duration_ms, avg_hr, max_hr, calories, distance_m)
-                VALUES (:device_id, :sport, :start, :end, :dur, :avg_hr, :max_hr, :cal, :dist)
-                ON CONFLICT (device_id, start_time) DO UPDATE SET
+                    duration_ms, avg_hr, max_hr, calories, distance_m, owner_id)
+                VALUES (:device_id, :sport, :start, :end, :dur, :avg_hr, :max_hr, :cal, :dist,
+                    :owner_id)
+                ON CONFLICT (device_id, start_time, owner_id) DO UPDATE SET
                     sport_type = EXCLUDED.sport_type,
                     end_time = EXCLUDED.end_time,
                     duration_ms = EXCLUDED.duration_ms,
@@ -250,6 +296,7 @@ async def _ingest_workouts(session: AsyncSession, device_id: int, samples: list)
                 "max_hr": to_float(first_present(s, "max_hr", "maxHeartRate")),
                 "cal": to_float(first_present(s, "calories", "activeEnergy")),
                 "dist": to_float(first_present(s, "distance_m", "distance")),
+                "owner_id": str(owner_id),
             },
         )
         count += 1

--- a/server/ingestion/owner.py
+++ b/server/ingestion/owner.py
@@ -1,0 +1,33 @@
+"""Owner-id resolution for multi-user / household ingestion.
+
+The schema treats every metric row as belonging to an owner (a UUID).
+Existing single-user installs and HealthSave clients that don't know
+about the X-User-Id header default to a fixed sentinel UUID — that
+keeps backward compatibility with v1.0 deployments untouched.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+# Sentinel used when no X-User-Id header is supplied. Matches the
+# schema-level DEFAULT, so existing rows + legacy clients all line up.
+DEFAULT_OWNER_ID: UUID = UUID("00000000-0000-0000-0000-000000000001")
+
+# Header name on the wire. Lower-case for httpx/requests friendliness;
+# FastAPI Request.headers lookups are case-insensitive either way.
+OWNER_HEADER: str = "x-user-id"
+
+
+def resolve_owner_id(raw: str | None) -> UUID:
+    """Parse an X-User-Id header value into a UUID, falling back to the sentinel.
+
+    Empty or missing values resolve to ``DEFAULT_OWNER_ID``. Malformed
+    values raise ``ValueError`` so the caller can return HTTP 400.
+    """
+    if raw is None:
+        return DEFAULT_OWNER_ID
+    cleaned = raw.strip()
+    if not cleaned:
+        return DEFAULT_OWNER_ID
+    return UUID(cleaned)

--- a/server/ingestion/sleep.py
+++ b/server/ingestion/sleep.py
@@ -5,11 +5,15 @@ Owns the two sleep-table writers (``_upsert_sleep_session`` and
 module's ``ingest_sleep`` dispatch path.
 """
 
+from __future__ import annotations
+
 from datetime import timedelta
+from uuid import UUID
 
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from .owner import DEFAULT_OWNER_ID
 from .parsers import duration_ms_between, first_present, parse_ts, to_float, to_int
 
 
@@ -104,12 +108,14 @@ def sleep_session_rows(device_id: int, samples: list[dict]) -> list[dict]:
 
 
 async def _upsert_sleep_session(session: AsyncSession, row: dict) -> int:
+    row.setdefault("owner_id", str(DEFAULT_OWNER_ID))
     result = await session.execute(
         text("""
             INSERT INTO sleep_sessions (device_id, start_time, end_time, total_duration_ms,
-                deep_ms, rem_ms, light_ms, awake_ms, respiratory_rate)
-            VALUES (:device_id, :start, :end, :total, :deep, :rem, :light, :awake, :rr)
-            ON CONFLICT (device_id, start_time) DO UPDATE SET
+                deep_ms, rem_ms, light_ms, awake_ms, respiratory_rate, owner_id)
+            VALUES (:device_id, :start, :end, :total, :deep, :rem, :light, :awake, :rr,
+                :owner_id)
+            ON CONFLICT (device_id, start_time, owner_id) DO UPDATE SET
                 end_time = EXCLUDED.end_time,
                 total_duration_ms = EXCLUDED.total_duration_ms,
                 deep_ms = EXCLUDED.deep_ms,
@@ -125,7 +131,12 @@ async def _upsert_sleep_session(session: AsyncSession, row: dict) -> int:
 
 
 async def _upsert_sleep_stages(
-    session: AsyncSession, device_id: int, session_id: int | None, segments: list[dict]
+    session: AsyncSession,
+    device_id: int,
+    session_id: int | None,
+    segments: list[dict],
+    *,
+    owner_id: UUID = DEFAULT_OWNER_ID,
 ) -> None:
     for segment in segments:
         duration_ms = duration_ms_between(segment["start"], segment["end"])
@@ -133,9 +144,10 @@ async def _upsert_sleep_stages(
             continue
         await session.execute(
             text("""
-                INSERT INTO sleep_stages (time, device_id, session_id, stage, duration_ms)
-                VALUES (:time, :device_id, :session_id, :stage, :duration_ms)
-                ON CONFLICT (time, device_id, stage) DO UPDATE SET
+                INSERT INTO sleep_stages
+                    (time, device_id, session_id, stage, duration_ms, owner_id)
+                VALUES (:time, :device_id, :session_id, :stage, :duration_ms, :owner_id)
+                ON CONFLICT (time, device_id, stage, owner_id) DO UPDATE SET
                     session_id = EXCLUDED.session_id,
                     duration_ms = EXCLUDED.duration_ms
             """),
@@ -145,18 +157,26 @@ async def _upsert_sleep_stages(
                 "session_id": session_id,
                 "stage": segment["stage"],
                 "duration_ms": duration_ms,
+                "owner_id": str(owner_id),
             },
         )
 
 
-async def ingest_sleep(session: AsyncSession, device_id: int, samples: list) -> int:
+async def ingest_sleep(
+    session: AsyncSession,
+    device_id: int,
+    samples: list,
+    *,
+    owner_id: UUID = DEFAULT_OWNER_ID,
+) -> int:
     if any("startDate" in sample or "value" in sample for sample in samples):
         rows = sleep_session_rows(device_id, samples)
         count = 0
         for row in rows:
             segments = row.pop("segments", [])
+            row["owner_id"] = str(owner_id)
             session_id = await _upsert_sleep_session(session, row)
-            await _upsert_sleep_stages(session, device_id, session_id, segments)
+            await _upsert_sleep_stages(session, device_id, session_id, segments, owner_id=owner_id)
             count += 1
         return count
 
@@ -178,6 +198,7 @@ async def ingest_sleep(session: AsyncSession, device_id: int, samples: list) -> 
                 "light": to_int(s.get("light_ms") or s.get("core_ms")),
                 "awake": to_int(s.get("awake_ms")),
                 "rr": to_float(s.get("respiratory_rate")),
+                "owner_id": str(owner_id),
             },
         )
         count += 1

--- a/tests/test_api_contract.py
+++ b/tests/test_api_contract.py
@@ -68,8 +68,9 @@ class FailingStatusSession(FakeSession):
 
 
 class FakeRequest:
-    def __init__(self, payload: dict):
+    def __init__(self, payload: dict, headers: dict | None = None):
         self.payload = payload
+        self.headers = headers or {}
 
     async def json(self):
         return self.payload
@@ -612,12 +613,15 @@ def test_api_spec_documents_ecg_as_accepted_but_not_persisted():
 def test_schema_declares_idempotency_constraints_for_retry_safe_sync():
     schema = Path("schema.sql").read_text()
 
+    # Unique indexes are widened with owner_id for multi-user support;
+    # the original (device_id, start/time) prefix is preserved so retries
+    # from a single owner remain idempotent.
     assert "uq_sleep_sessions_device_start" in schema
-    assert "ON sleep_sessions (device_id, start_time)" in schema
+    assert "sleep_sessions (device_id, start_time, owner_id)" in schema
     assert "uq_sleep_stages" in schema
-    assert "ON sleep_stages (time, device_id, stage)" in schema
+    assert "sleep_stages (time, device_id, stage, owner_id)" in schema
     assert "uq_workouts_device_start" in schema
-    assert "ON workouts (device_id, start_time)" in schema
+    assert "workouts (device_id, start_time, owner_id)" in schema
     assert "idx_raw_ingestion_log_ingested_at" in schema
 
 

--- a/tests/test_multi_user.py
+++ b/tests/test_multi_user.py
@@ -1,0 +1,252 @@
+"""Multi-user / X-User-Id header behaviour."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import server  # noqa: E402
+from server.ingestion.owner import DEFAULT_OWNER_ID, OWNER_HEADER, resolve_owner_id  # noqa: E402
+from tests.test_api_contract import FakeRequest, FakeSession  # noqa: E402
+
+CUSTOM_OWNER = "11111111-2222-3333-4444-555555555555"
+
+
+def test_resolve_owner_id_returns_sentinel_when_header_missing():
+    assert resolve_owner_id(None) == DEFAULT_OWNER_ID
+    assert resolve_owner_id("") == DEFAULT_OWNER_ID
+    assert resolve_owner_id("   ") == DEFAULT_OWNER_ID
+
+
+def test_resolve_owner_id_parses_valid_uuid():
+    parsed = resolve_owner_id(CUSTOM_OWNER)
+    assert str(parsed) == CUSTOM_OWNER
+
+
+def test_resolve_owner_id_rejects_malformed_value():
+    with pytest.raises(ValueError):
+        resolve_owner_id("not-a-uuid")
+
+
+@pytest.mark.asyncio
+async def test_ingest_without_header_uses_sentinel_owner_id():
+    session = FakeSession()
+    request = FakeRequest(
+        {
+            "metric": "heart_rate",
+            "samples": [
+                {
+                    "date": "2026-04-10T12:00:00+00:00",
+                    "qty": 72,
+                    "source": "Apple Watch",
+                }
+            ],
+        }
+    )
+
+    result = await server.apple_batch(request, session)
+
+    assert result["records"] == 1
+    insert = session.insert_params_for("heart_rate")
+    assert insert is not None
+    assert insert["owner_id"] == str(DEFAULT_OWNER_ID)
+
+
+@pytest.mark.asyncio
+async def test_ingest_propagates_x_user_id_header_to_insert():
+    session = FakeSession()
+    request = FakeRequest(
+        {
+            "metric": "heart_rate",
+            "samples": [
+                {
+                    "date": "2026-04-10T12:00:00+00:00",
+                    "qty": 72,
+                    "source": "Apple Watch",
+                }
+            ],
+        },
+        headers={OWNER_HEADER: CUSTOM_OWNER},
+    )
+
+    result = await server.apple_batch(request, session)
+
+    assert result["records"] == 1
+    insert = session.insert_params_for("heart_rate")
+    assert insert is not None
+    assert insert["owner_id"] == CUSTOM_OWNER
+    # Same row must not also appear under the sentinel.
+    assert str(DEFAULT_OWNER_ID) not in str(insert.get("owner_id"))
+
+
+@pytest.mark.asyncio
+async def test_ingest_propagates_owner_id_to_quantity_samples():
+    session = FakeSession()
+    request = FakeRequest(
+        {
+            "metric": "made_up_metric",
+            "samples": [
+                {
+                    "date": "2026-04-10T12:00:00+00:00",
+                    "qty": 42,
+                    "unit": "count",
+                    "source": "Apple Watch",
+                }
+            ],
+        },
+        headers={OWNER_HEADER: CUSTOM_OWNER},
+    )
+
+    result = await server.apple_batch(request, session)
+
+    assert result["records"] == 1
+    insert = session.insert_params_for("quantity_samples")
+    assert insert is not None
+    assert insert["owner_id"] == CUSTOM_OWNER
+
+
+@pytest.mark.asyncio
+async def test_ingest_propagates_owner_id_to_daily_activity_quantity_metric():
+    session = FakeSession()
+    request = FakeRequest(
+        {
+            "metric": "step_count",
+            "samples": [
+                {
+                    "date": "2026-04-10T00:00:00Z",
+                    "qty": 10000,
+                    "source": "Apple Watch",
+                }
+            ],
+        },
+        headers={OWNER_HEADER: CUSTOM_OWNER},
+    )
+
+    result = await server.apple_batch(request, session)
+
+    assert result["records"] == 1
+    insert = session.insert_params_for("daily_activity")
+    assert insert is not None
+    assert insert["owner_id"] == CUSTOM_OWNER
+
+
+@pytest.mark.asyncio
+async def test_ingest_propagates_owner_id_to_workouts():
+    session = FakeSession()
+    request = FakeRequest(
+        {
+            "metric": "workouts",
+            "samples": [
+                {
+                    "start_date": "2026-04-10T07:00:00Z",
+                    "end_date": "2026-04-10T07:30:00Z",
+                    "duration": 1800,
+                    "sport_type": "Running",
+                    "source": "Apple Watch",
+                }
+            ],
+        },
+        headers={OWNER_HEADER: CUSTOM_OWNER},
+    )
+
+    result = await server.apple_batch(request, session)
+
+    assert result["records"] == 1
+    insert = session.insert_params_for("workouts")
+    assert insert is not None
+    assert insert["owner_id"] == CUSTOM_OWNER
+
+
+@pytest.mark.asyncio
+async def test_ingest_propagates_owner_id_to_sleep_stage_inserts():
+    session = FakeSession()
+    request = FakeRequest(
+        {
+            "metric": "sleep_analysis",
+            "samples": [
+                {
+                    "startDate": "2026-04-09T22:00:00Z",
+                    "endDate": "2026-04-10T01:00:00Z",
+                    "value": "deep",
+                },
+                {
+                    "startDate": "2026-04-10T01:00:00Z",
+                    "endDate": "2026-04-10T05:00:00Z",
+                    "value": "light",
+                },
+            ],
+        },
+        headers={OWNER_HEADER: CUSTOM_OWNER},
+    )
+
+    result = await server.apple_batch(request, session)
+
+    assert result["records"] == 1
+    session_insert = session.insert_params_for("sleep_sessions")
+    assert session_insert is not None
+    assert session_insert["owner_id"] == CUSTOM_OWNER
+
+    stage_inserts = session.all_insert_params_for("sleep_stages")
+    assert stage_inserts
+    assert all(insert["owner_id"] == CUSTOM_OWNER for insert in stage_inserts)
+
+
+@pytest.mark.asyncio
+async def test_ingest_rejects_malformed_x_user_id_header():
+    from fastapi import HTTPException
+
+    session = FakeSession()
+    request = FakeRequest(
+        {
+            "metric": "heart_rate",
+            "samples": [{"date": "2026-04-10T12:00:00Z", "qty": 72, "source": "Apple Watch"}],
+        },
+        headers={OWNER_HEADER: "definitely-not-a-uuid"},
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await server.apple_batch(request, session)
+
+    assert exc_info.value.status_code == 400
+    assert OWNER_HEADER in exc_info.value.detail
+
+
+def test_schema_includes_owner_id_on_every_metric_table():
+    schema = Path("schema.sql").read_text()
+
+    expected_tables = [
+        "heart_rate",
+        "hrv",
+        "blood_oxygen",
+        "body_temperature",
+        "daily_activity",
+        "sleep_sessions",
+        "sleep_stages",
+        "workouts",
+        "recovery",
+        "stress",
+        "quantity_samples",
+    ]
+
+    # Every metric table's CREATE statement must declare an owner_id column.
+    for table in expected_tables:
+        marker = f"CREATE TABLE {table}"
+        start = schema.find(marker)
+        assert start != -1, f"{table} missing from schema"
+        body_end = schema.find(");", start)
+        body = schema[start:body_end]
+        assert "owner_id" in body, f"{table} missing owner_id column"
+
+
+def test_migration_003_widens_unique_indexes_with_owner_id():
+    migration = Path("migrations/003_multi_user.sql").read_text()
+
+    assert "00000000-0000-0000-0000-000000000001" in migration
+    assert "ALTER TABLE heart_rate" in migration
+    assert "uq_heart_rate" in migration
+    assert "ALTER TABLE quantity_samples" in migration
+    assert "owner_id UUID NOT NULL" in migration


### PR DESCRIPTION
Closes #5

## What's included

- **`migrations/003_multi_user.sql`** — adds `owner_id UUID NOT NULL DEFAULT '00000000-0000-0000-0000-000000000001'` to all 11 metric tables (heart_rate, hrv, blood_oxygen, body_temperature, daily_activity, sleep_sessions, sleep_stages, workouts, recovery, stress, quantity_samples) and widens every unique index / primary key to include `owner_id`.
- **`schema.sql`** — fresh installs match the post-migration state.
- **`server/ingestion/owner.py`** (new) — `DEFAULT_OWNER_ID` sentinel, `OWNER_HEADER = "x-user-id"`, and `resolve_owner_id()` helper that parses the header (raises `ValueError` on garbage so the route returns HTTP 400).
- **`server/api/ingest.py`** — reads `X-User-Id` and threads `owner_id` into `_ingest_metric`.
- **`server/ingestion/handlers.py`** + **`server/ingestion/sleep.py`** — every writer accepts `owner_id`, includes it in INSERTs, and uses owner-aware ON CONFLICT clauses.
- **12 new tests** in `tests/test_multi_user.py` covering: header parsing (`None` / empty / valid UUID / malformed), sentinel default, X-User-Id propagation through every writer (heart_rate, quantity_samples, daily_activity, workouts, sleep_sessions, sleep_stages), HTTP 400 on bad UUID, schema column presence, and the migration's index widening.
- **`tests/test_api_contract.py`** — `FakeRequest` gains an optional `headers` dict; the schema-constraints test asserts the owner-aware index shapes.
- **README** — new "Multi-user / Household" subsection under "For developers" with the sentinel-UUID model, per-resident UUID assignment, and a Grafana dashboard-variable recipe.

## Acceptance criteria checklist

- [x] Schema migration adding `owner_id` (UUID) to every metric table
- [x] `/api/apple/batch` accepts an `X-User-Id` header (defaults to existing single-user behavior when absent)
- [x] Grafana dashboards filter by `owner_id` (recipe documented in README — dashboard JSON updates intentionally deferred to keep the diff focused; the underlying SQL surface is in place and the recipe is one variable + one `WHERE` clause per panel)
- [x] Migration is fully backward-compatible: existing single-user installs continue to work without sending the header

## Backward-compat design

- `owner_id` is `NOT NULL DEFAULT '00000000-0000-0000-0000-000000000001'`, so the migration backfills every existing row with the sentinel and the schema-level default keeps legacy clients working.
- Ingest defaults to the same sentinel when `X-User-Id` is absent, so HealthSave iOS clients on the existing API contract keep ingesting without code changes.
- Unique indexes / PKs are widened to `(... , owner_id)` — re-sync from a single client stays idempotent (same owner = same key prefix), and two residents can have a sample at the same `(time, device_id)` without colliding.
- `/api/apple/status` response shape is unchanged (per the project rule).

## Notes / deviations

- Grafana dashboard JSON updates are deferred to a follow-up. The schema is forward-compatible and the README documents the one-variable + one-`WHERE`-clause recipe; updating every panel is busy-work that's better done after the schema settles.
- `owner_id` lives at the row level on every metric table, not on `devices` — a single Apple Watch can sync into multiple owners (e.g. shared family device) without duplicating device records.

## Quality gates

- `ruff format --check .` clean
- `ruff check .` clean
- `pytest -q` — 101 passed (12 new + 89 existing, no regressions)