### PR TITLE
refactor(ingest): extract IngestStorage protocol seam (towards #4)

### DIFF
--- a/server/api/ingest.py
+++ b/server/api/ingest.py
@@ -7,14 +7,9 @@ from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
 from pydantic import ValidationError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from ..ingestion.handlers import (
-    _get_or_create_device,
-    _ingest_metric,
-    _log_raw_ingestion,
-    _mark_raw_ingestion_processed,
-)
 from ..ingestion.owner import OWNER_HEADER, resolve_owner_id
 from ..ingestion.parsers import group_samples_by_device
+from ..ingestion.storage import IngestStorage, default_storage
 from ..models.batch import BatchPayload
 from .deps import get_session, verify_api_key
 from .metrics import INGEST_BATCHES, INGEST_DURATION, INGEST_ROWS
@@ -55,23 +50,25 @@ async def apple_batch(
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=f"invalid {OWNER_HEADER}: {exc}") from exc
 
+    storage = _resolve_storage(request)
+
     metric = payload.metric.strip() or "unknown"
     batch_idx = payload.batch_index
     total = payload.total_batches
     samples = payload.samples
 
     if not samples:
-        raw_log_id = await _log_raw_ingestion(session, None, raw_payload)
+        raw_log_id = await storage.log_raw_ingestion(session, None, raw_payload)
         await session.commit()
-        await _mark_raw_ingestion_processed(session, raw_log_id)
+        await storage.mark_raw_ingestion_processed(session, raw_log_id)
         await session.commit()
         _observe_ingest_metrics(metric=metric, rows=0, started_at=started_at)
         return {"status": "empty", "metric": metric, "batch": batch_idx, "records": 0}
 
     sample_groups = group_samples_by_device(samples)
     first_device_name, _ = sample_groups[0]
-    first_device_id = await _get_or_create_device(session, first_device_name)
-    raw_log_id = await _log_raw_ingestion(session, first_device_id, raw_payload)
+    first_device_id = await storage.get_or_create_device(session, first_device_name)
+    raw_log_id = await storage.log_raw_ingestion(session, first_device_id, raw_payload)
     await session.commit()
     count = 0
 
@@ -79,11 +76,11 @@ async def apple_batch(
         device_id = (
             first_device_id
             if device_name == first_device_name
-            else await _get_or_create_device(session, device_name)
+            else await storage.get_or_create_device(session, device_name)
         )
-        count += await _ingest_metric(session, device_id, metric, device_samples, owner_id)
+        count += await storage.ingest_metric(session, device_id, metric, device_samples, owner_id)
 
-    await _mark_raw_ingestion_processed(session, raw_log_id)
+    await storage.mark_raw_ingestion_processed(session, raw_log_id)
     await session.commit()
     _observe_ingest_metrics(metric=metric, rows=count, started_at=started_at)
     log.info("Ingested %d records for %s (batch %d/%d)", count, metric, batch_idx + 1, total)
@@ -96,6 +93,15 @@ async def apple_batch(
         "total_batches": total,
         "records": count,
     }
+
+
+def _resolve_storage(request: Request) -> IngestStorage:
+    """Read the configured storage backend off ``app.state``, falling back
+    to the module-level default for unit tests that hit the route without
+    a full FastAPI app + lifespan."""
+    state = getattr(getattr(request, "app", None), "state", None)
+    storage = getattr(state, "storage", None)
+    return storage if storage is not None else default_storage
 
 
 def _observe_ingest_metrics(*, metric: str, rows: int, started_at: float) -> None:

--- a/server/api/ingest.py
+++ b/server/api/ingest.py
@@ -9,7 +9,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..ingestion.owner import OWNER_HEADER, resolve_owner_id
 from ..ingestion.parsers import group_samples_by_device
-from ..ingestion.storage import IngestStorage, default_storage
+from ..ingestion.storage import (
+    AuditLog,
+    IngestStorage,
+    default_audit_log,
+    default_storage,
+)
 from ..models.batch import BatchPayload
 from .deps import get_session, verify_api_key
 from .metrics import INGEST_BATCHES, INGEST_DURATION, INGEST_ROWS
@@ -51,6 +56,7 @@ async def apple_batch(
         raise HTTPException(status_code=400, detail=f"invalid {OWNER_HEADER}: {exc}") from exc
 
     storage = _resolve_storage(request)
+    audit = _resolve_audit_log(request)
 
     metric = payload.metric.strip() or "unknown"
     batch_idx = payload.batch_index
@@ -58,17 +64,18 @@ async def apple_batch(
     samples = payload.samples
 
     if not samples:
-        raw_log_id = await storage.log_raw_ingestion(session, None, raw_payload)
+        raw_log_id = await audit.log_raw(session, None, raw_payload) if audit else None
         await session.commit()
-        await storage.mark_raw_ingestion_processed(session, raw_log_id)
-        await session.commit()
+        if audit and raw_log_id is not None:
+            await audit.mark_processed(session, raw_log_id)
+            await session.commit()
         _observe_ingest_metrics(metric=metric, rows=0, started_at=started_at)
         return {"status": "empty", "metric": metric, "batch": batch_idx, "records": 0}
 
     sample_groups = group_samples_by_device(samples)
     first_device_name, _ = sample_groups[0]
     first_device_id = await storage.get_or_create_device(session, first_device_name)
-    raw_log_id = await storage.log_raw_ingestion(session, first_device_id, raw_payload)
+    raw_log_id = await audit.log_raw(session, first_device_id, raw_payload) if audit else None
     await session.commit()
     count = 0
 
@@ -80,7 +87,8 @@ async def apple_batch(
         )
         count += await storage.ingest_metric(session, device_id, metric, device_samples, owner_id)
 
-    await storage.mark_raw_ingestion_processed(session, raw_log_id)
+    if audit and raw_log_id is not None:
+        await audit.mark_processed(session, raw_log_id)
     await session.commit()
     _observe_ingest_metrics(metric=metric, rows=count, started_at=started_at)
     log.info("Ingested %d records for %s (batch %d/%d)", count, metric, batch_idx + 1, total)
@@ -102,6 +110,23 @@ def _resolve_storage(request: Request) -> IngestStorage:
     state = getattr(getattr(request, "app", None), "state", None)
     storage = getattr(state, "storage", None)
     return storage if storage is not None else default_storage
+
+
+def _resolve_audit_log(request: Request) -> AuditLog | None:
+    """Read the optional audit log backend off ``app.state``.
+
+    Returns ``None`` when the configured backend doesn't ship one
+    (InfluxDB-style append-only stores). The route skips audit calls
+    in that case.
+    """
+    state = getattr(getattr(request, "app", None), "state", None)
+    if state is None:
+        return default_audit_log
+    # ``hasattr`` lets a backend explicitly disable audit by setting the
+    # attribute to None on app.state, distinct from "not configured".
+    if hasattr(state, "audit_log"):
+        return state.audit_log
+    return default_audit_log
 
 
 def _observe_ingest_metrics(*, metric: str, rows: int, started_at: float) -> None:

--- a/server/ingestion/storage.py
+++ b/server/ingestion/storage.py
@@ -1,101 +1,93 @@
-"""Pluggable ingest storage backend.
+"""Pluggable ingest storage backends.
 
-The ingest path used to call ``server.ingestion.handlers._ingest_metric``
-directly. That tied the API contract to a single SQL implementation,
-which is fine for v1.0 but makes it impossible to add a second backend
-(InfluxDB, DuckDB, a CSV sink for testing) without editing every route.
+Two protocols, by design:
 
-This module introduces a small ``IngestStorage`` protocol that captures
-exactly the operations the ingest route needs. ``PostgresIngestStorage``
-is the default backend and keeps wire-compat with the existing
-TimescaleDB schema by delegating to the handlers in
-``server.ingestion.handlers``. Future backends implement the same
-protocol — there is intentionally nothing TimescaleDB-specific in the
-protocol surface.
+  * ``IngestStorage`` — what every backend MUST implement: resolve a
+    device identity, persist samples for a metric. Backend-agnostic
+    types (the ``session`` parameter is opaque ``Any`` so a backend
+    can use a SQLAlchemy AsyncSession, an httpx Client, or nothing
+    at all).
 
-The route picks a storage instance via ``request.app.state.storage`` if
-set (lifespan-configured) and falls back to a module-level default so
-unit tests that construct routes directly don't have to wire up an app.
+  * ``AuditLog`` — OPTIONAL capability. Postgres ships an audit log
+    (``raw_ingestion_log``); InfluxDB is append-only and has no
+    UPDATE, so it can't implement this protocol cleanly. The route
+    treats audit logging as best-effort: if the configured backend
+    provides an ``audit_log``, every batch is logged + marked
+    processed; if not, the route skips silently.
+
+Default wiring: the lifespan (``server.main``) creates a
+``PostgresIngestStorage`` and a ``PostgresAuditLog`` and stashes
+both on ``app.state``. Tests that hit routes without a full app
+fall back to module-level singletons.
 """
 
 from __future__ import annotations
 
-from typing import Protocol, runtime_checkable
+from typing import Any, Protocol, runtime_checkable
 from uuid import UUID
-
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from . import handlers
 
 
 @runtime_checkable
 class IngestStorage(Protocol):
-    """Operations the ingest route needs from a storage backend."""
+    """Minimum surface every storage backend must implement."""
 
-    async def get_or_create_device(self, session: AsyncSession, device_type: str) -> int:
-        """Resolve a ``device_type`` label to a numeric device id, creating one
-        if necessary."""
+    async def get_or_create_device(self, session: Any, device_type: str) -> int | str:
+        """Resolve a ``device_type`` label to a backend-specific identity.
 
-    async def log_raw_ingestion(
-        self,
-        session: AsyncSession,
-        device_id: int | None,
-        raw_payload: dict,
-    ) -> int | None:
-        """Persist the raw inbound payload for the audit trail. Returns the
-        new log id (or ``None`` for backends that don't keep an audit log)."""
-
-    async def mark_raw_ingestion_processed(
-        self,
-        session: AsyncSession,
-        raw_log_id: int | None,
-    ) -> None:
-        """Flip the audit row to ``processed = true`` after the batch commit
-        succeeds. No-op when ``raw_log_id`` is ``None``."""
+        TimescaleDB returns the auto-incrementing ``devices.id`` (int).
+        InfluxDB-style backends can return the device_type string itself
+        (no ID column needed since identity flows through tags).
+        """
 
     async def ingest_metric(
         self,
-        session: AsyncSession,
-        device_id: int,
+        session: Any,
+        device_id: int | str,
         metric: str,
         samples: list[dict],
         owner_id: UUID,
     ) -> int:
-        """Persist parsed samples for ``metric`` under ``owner_id``. Returns
-        the count of records written."""
+        """Persist parsed samples; return the count of records written."""
+
+
+@runtime_checkable
+class AuditLog(Protocol):
+    """Optional capability: persist + mark raw ingest payloads.
+
+    This is a Postgres-shaped concern (auto-incrementing ID, UPDATE on
+    a status column). Append-only backends like InfluxDB do not need
+    to implement it; the route falls back to skipping audit calls.
+    """
+
+    async def log_raw(
+        self,
+        session: Any,
+        device_id: int | str | None,
+        raw_payload: dict,
+    ) -> Any:
+        """Record the raw inbound payload. Return value is an opaque
+        token the route hands back to ``mark_processed``."""
+
+    async def mark_processed(self, session: Any, raw_log_id: Any) -> None:
+        """Flip the audit row to processed=true after the batch commit."""
 
 
 class PostgresIngestStorage:
-    """Default backend: TimescaleDB via the existing handlers.
+    """Default backend — TimescaleDB via the existing handlers.
 
-    Each method is a thin pass-through. Behavior is identical to the
-    pre-protocol code path, so existing tests + the iOS app contract are
-    untouched. The point is to give the ingest route a single seam to
-    swap a backend behind, not to re-architect the writers themselves.
+    Each method delegates to the equivalent function in
+    ``server.ingestion.handlers``. No SQL changes, no behavior change.
     """
 
-    async def get_or_create_device(self, session: AsyncSession, device_type: str) -> int:
+    async def get_or_create_device(self, session: Any, device_type: str) -> int:
         return await handlers._get_or_create_device(session, device_type)
-
-    async def log_raw_ingestion(
-        self,
-        session: AsyncSession,
-        device_id: int | None,
-        raw_payload: dict,
-    ) -> int | None:
-        return await handlers._log_raw_ingestion(session, device_id, raw_payload)
-
-    async def mark_raw_ingestion_processed(
-        self,
-        session: AsyncSession,
-        raw_log_id: int | None,
-    ) -> None:
-        await handlers._mark_raw_ingestion_processed(session, raw_log_id)
 
     async def ingest_metric(
         self,
-        session: AsyncSession,
-        device_id: int,
+        session: Any,
+        device_id: int | str,
         metric: str,
         samples: list[dict],
         owner_id: UUID,
@@ -103,8 +95,24 @@ class PostgresIngestStorage:
         return await handlers._ingest_metric(session, device_id, metric, samples, owner_id)
 
 
-# Module-level default. The ingest route uses this when ``app.state.storage``
-# is unset (e.g. in unit tests that construct routes directly without a full
-# FastAPI lifespan). Production wiring sets ``app.state.storage`` from config
-# in ``server.main``.
+class PostgresAuditLog:
+    """Postgres-only audit log backed by the ``raw_ingestion_log`` table."""
+
+    async def log_raw(
+        self,
+        session: Any,
+        device_id: int | str | None,
+        raw_payload: dict,
+    ) -> int | None:
+        return await handlers._log_raw_ingestion(session, device_id, raw_payload)
+
+    async def mark_processed(self, session: Any, raw_log_id: Any) -> None:
+        await handlers._mark_raw_ingestion_processed(session, raw_log_id)
+
+
+# Module-level defaults — the route falls back to these when
+# ``app.state.storage`` / ``app.state.audit_log`` are unset (e.g. in
+# unit tests that construct routes directly without a full FastAPI
+# lifespan). Production wiring sets both in ``server.main``.
 default_storage: IngestStorage = PostgresIngestStorage()
+default_audit_log: AuditLog | None = PostgresAuditLog()

--- a/server/ingestion/storage.py
+++ b/server/ingestion/storage.py
@@ -1,0 +1,110 @@
+"""Pluggable ingest storage backend.
+
+The ingest path used to call ``server.ingestion.handlers._ingest_metric``
+directly. That tied the API contract to a single SQL implementation,
+which is fine for v1.0 but makes it impossible to add a second backend
+(InfluxDB, DuckDB, a CSV sink for testing) without editing every route.
+
+This module introduces a small ``IngestStorage`` protocol that captures
+exactly the operations the ingest route needs. ``PostgresIngestStorage``
+is the default backend and keeps wire-compat with the existing
+TimescaleDB schema by delegating to the handlers in
+``server.ingestion.handlers``. Future backends implement the same
+protocol — there is intentionally nothing TimescaleDB-specific in the
+protocol surface.
+
+The route picks a storage instance via ``request.app.state.storage`` if
+set (lifespan-configured) and falls back to a module-level default so
+unit tests that construct routes directly don't have to wire up an app.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from . import handlers
+
+
+@runtime_checkable
+class IngestStorage(Protocol):
+    """Operations the ingest route needs from a storage backend."""
+
+    async def get_or_create_device(self, session: AsyncSession, device_type: str) -> int:
+        """Resolve a ``device_type`` label to a numeric device id, creating one
+        if necessary."""
+
+    async def log_raw_ingestion(
+        self,
+        session: AsyncSession,
+        device_id: int | None,
+        raw_payload: dict,
+    ) -> int | None:
+        """Persist the raw inbound payload for the audit trail. Returns the
+        new log id (or ``None`` for backends that don't keep an audit log)."""
+
+    async def mark_raw_ingestion_processed(
+        self,
+        session: AsyncSession,
+        raw_log_id: int | None,
+    ) -> None:
+        """Flip the audit row to ``processed = true`` after the batch commit
+        succeeds. No-op when ``raw_log_id`` is ``None``."""
+
+    async def ingest_metric(
+        self,
+        session: AsyncSession,
+        device_id: int,
+        metric: str,
+        samples: list[dict],
+        owner_id: UUID,
+    ) -> int:
+        """Persist parsed samples for ``metric`` under ``owner_id``. Returns
+        the count of records written."""
+
+
+class PostgresIngestStorage:
+    """Default backend: TimescaleDB via the existing handlers.
+
+    Each method is a thin pass-through. Behavior is identical to the
+    pre-protocol code path, so existing tests + the iOS app contract are
+    untouched. The point is to give the ingest route a single seam to
+    swap a backend behind, not to re-architect the writers themselves.
+    """
+
+    async def get_or_create_device(self, session: AsyncSession, device_type: str) -> int:
+        return await handlers._get_or_create_device(session, device_type)
+
+    async def log_raw_ingestion(
+        self,
+        session: AsyncSession,
+        device_id: int | None,
+        raw_payload: dict,
+    ) -> int | None:
+        return await handlers._log_raw_ingestion(session, device_id, raw_payload)
+
+    async def mark_raw_ingestion_processed(
+        self,
+        session: AsyncSession,
+        raw_log_id: int | None,
+    ) -> None:
+        await handlers._mark_raw_ingestion_processed(session, raw_log_id)
+
+    async def ingest_metric(
+        self,
+        session: AsyncSession,
+        device_id: int,
+        metric: str,
+        samples: list[dict],
+        owner_id: UUID,
+    ) -> int:
+        return await handlers._ingest_metric(session, device_id, metric, samples, owner_id)
+
+
+# Module-level default. The ingest route uses this when ``app.state.storage``
+# is unset (e.g. in unit tests that construct routes directly without a full
+# FastAPI lifespan). Production wiring sets ``app.state.storage`` from config
+# in ``server.main``.
+default_storage: IngestStorage = PostgresIngestStorage()

--- a/server/main.py
+++ b/server/main.py
@@ -25,7 +25,7 @@ from analysis.scheduler import AnalysisScheduler
 
 from .api import health_routes, ingest, insights, metrics, status
 from .db.session import async_session, engine
-from .ingestion.storage import PostgresIngestStorage
+from .ingestion.storage import PostgresAuditLog, PostgresIngestStorage
 
 log = logging.getLogger("healthsave")
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s %(message)s")
@@ -43,6 +43,7 @@ async def lifespan(a: FastAPI):
     a.state.analysis_engine = analysis_engine
     a.state.scheduler = scheduler
     a.state.storage = PostgresIngestStorage()
+    a.state.audit_log = PostgresAuditLog()
     scheduler.start()
     try:
         yield

--- a/server/main.py
+++ b/server/main.py
@@ -25,6 +25,7 @@ from analysis.scheduler import AnalysisScheduler
 
 from .api import health_routes, ingest, insights, metrics, status
 from .db.session import async_session, engine
+from .ingestion.storage import PostgresIngestStorage
 
 log = logging.getLogger("healthsave")
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s %(message)s")
@@ -41,6 +42,7 @@ async def lifespan(a: FastAPI):
     a.state.analysis_config = analysis_config
     a.state.analysis_engine = analysis_engine
     a.state.scheduler = scheduler
+    a.state.storage = PostgresIngestStorage()
     scheduler.start()
     try:
         yield

--- a/tests/test_storage_protocol.py
+++ b/tests/test_storage_protocol.py
@@ -1,0 +1,126 @@
+"""Verify the IngestStorage protocol seam.
+
+Two concerns:
+  * The default Postgres backend implements IngestStorage and behaves
+    identically to the pre-protocol code path (no regression).
+  * A test backend can swap in via app.state.storage and the route
+    routes through it instead of the default.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from uuid import UUID
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import server  # noqa: E402
+from server.ingestion.storage import (  # noqa: E402
+    IngestStorage,
+    PostgresIngestStorage,
+    default_storage,
+)
+from tests.test_api_contract import FakeRequest, FakeSession  # noqa: E402
+
+
+def test_postgres_ingest_storage_is_protocol_compliant():
+    storage = PostgresIngestStorage()
+    assert isinstance(storage, IngestStorage)
+
+
+def test_module_default_storage_is_postgres():
+    assert isinstance(default_storage, PostgresIngestStorage)
+
+
+@pytest.mark.asyncio
+async def test_route_uses_module_default_when_app_state_absent():
+    """FakeRequest doesn't carry an app — the route must fall back to default."""
+    session = FakeSession()
+    request = FakeRequest(
+        {
+            "metric": "heart_rate",
+            "samples": [{"date": "2026-04-10T12:00:00Z", "qty": 72, "source": "Apple Watch"}],
+        }
+    )
+
+    result = await server.apple_batch(request, session)
+
+    assert result["records"] == 1
+
+
+class _RecordingStorage:
+    """Test backend that captures arguments instead of writing anywhere."""
+
+    def __init__(self):
+        self.calls: list[tuple] = []
+
+    async def get_or_create_device(self, session, device_type):
+        self.calls.append(("device", device_type))
+        return 1
+
+    async def log_raw_ingestion(self, session, device_id, raw_payload):
+        self.calls.append(("log_raw", device_id))
+        return 99
+
+    async def mark_raw_ingestion_processed(self, session, raw_log_id):
+        self.calls.append(("mark_processed", raw_log_id))
+
+    async def ingest_metric(self, session, device_id, metric, samples, owner_id):
+        self.calls.append(("ingest", metric, len(samples), str(owner_id)))
+        return len(samples)
+
+
+@pytest.mark.asyncio
+async def test_route_dispatches_through_app_state_storage():
+    storage = _RecordingStorage()
+    session = FakeSession()
+    request = FakeRequest(
+        {
+            "metric": "heart_rate",
+            "samples": [
+                {"date": "2026-04-10T12:00:00Z", "qty": 72, "source": "Apple Watch"},
+                {"date": "2026-04-10T12:00:01Z", "qty": 73, "source": "Apple Watch"},
+            ],
+        }
+    )
+    request.app = type("App", (), {"state": type("State", (), {"storage": storage})()})()
+
+    result = await server.apple_batch(request, session)
+
+    assert result["records"] == 2
+    kinds = [call[0] for call in storage.calls]
+    # Both samples share the "Apple Watch" source -> single device group ->
+    # one ingest call, one mark_processed call.
+    assert kinds == ["device", "log_raw", "ingest", "mark_processed"]
+    ingest_call = next(c for c in storage.calls if c[0] == "ingest")
+    assert ingest_call[1] == "heart_rate"
+    assert ingest_call[2] == 2
+
+
+@pytest.mark.asyncio
+async def test_recording_storage_satisfies_protocol():
+    """Smoke check: the test backend must be IngestStorage-compatible."""
+    storage = _RecordingStorage()
+    assert isinstance(storage, IngestStorage)
+
+
+@pytest.mark.asyncio
+async def test_swappable_storage_receives_resolved_owner_id():
+    storage = _RecordingStorage()
+    session = FakeSession()
+    request = FakeRequest(
+        {
+            "metric": "heart_rate",
+            "samples": [{"date": "2026-04-10T12:00:00Z", "qty": 72, "source": "Apple Watch"}],
+        },
+        headers={"x-user-id": "11111111-2222-3333-4444-555555555555"},
+    )
+    request.app = type("App", (), {"state": type("State", (), {"storage": storage})()})()
+
+    await server.apple_batch(request, session)
+
+    ingest_call = next(c for c in storage.calls if c[0] == "ingest")
+    assert UUID(ingest_call[3]) == UUID("11111111-2222-3333-4444-555555555555")

--- a/tests/test_storage_protocol.py
+++ b/tests/test_storage_protocol.py
@@ -1,10 +1,13 @@
-"""Verify the IngestStorage protocol seam.
+"""Verify the IngestStorage / AuditLog protocol seam.
 
-Two concerns:
-  * The default Postgres backend implements IngestStorage and behaves
+Three concerns:
+  * The default Postgres backend implements both protocols and behaves
     identically to the pre-protocol code path (no regression).
-  * A test backend can swap in via app.state.storage and the route
-    routes through it instead of the default.
+  * A test backend without an audit log can swap in via app.state and
+    the route gracefully skips audit calls (covers the InfluxDB shape:
+    append-only, no UPDATE).
+  * X-User-Id propagates through the seam regardless of which backend
+    is plugged in.
 """
 
 from __future__ import annotations
@@ -19,25 +22,32 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 import server  # noqa: E402
 from server.ingestion.storage import (  # noqa: E402
+    AuditLog,
     IngestStorage,
+    PostgresAuditLog,
     PostgresIngestStorage,
+    default_audit_log,
     default_storage,
 )
 from tests.test_api_contract import FakeRequest, FakeSession  # noqa: E402
 
 
-def test_postgres_ingest_storage_is_protocol_compliant():
-    storage = PostgresIngestStorage()
-    assert isinstance(storage, IngestStorage)
+def test_postgres_ingest_storage_implements_protocol():
+    assert isinstance(PostgresIngestStorage(), IngestStorage)
 
 
-def test_module_default_storage_is_postgres():
+def test_postgres_audit_log_implements_protocol():
+    assert isinstance(PostgresAuditLog(), AuditLog)
+
+
+def test_module_defaults_are_postgres():
     assert isinstance(default_storage, PostgresIngestStorage)
+    assert isinstance(default_audit_log, PostgresAuditLog)
 
 
 @pytest.mark.asyncio
 async def test_route_uses_module_default_when_app_state_absent():
-    """FakeRequest doesn't carry an app — the route must fall back to default."""
+    """FakeRequest doesn't carry an app — the route must fall back to defaults."""
     session = FakeSession()
     request = FakeRequest(
         {
@@ -52,7 +62,7 @@ async def test_route_uses_module_default_when_app_state_absent():
 
 
 class _RecordingStorage:
-    """Test backend that captures arguments instead of writing anywhere."""
+    """Storage-only test backend (no audit log)."""
 
     def __init__(self):
         self.calls: list[tuple] = []
@@ -61,21 +71,33 @@ class _RecordingStorage:
         self.calls.append(("device", device_type))
         return 1
 
-    async def log_raw_ingestion(self, session, device_id, raw_payload):
-        self.calls.append(("log_raw", device_id))
-        return 99
-
-    async def mark_raw_ingestion_processed(self, session, raw_log_id):
-        self.calls.append(("mark_processed", raw_log_id))
-
     async def ingest_metric(self, session, device_id, metric, samples, owner_id):
         self.calls.append(("ingest", metric, len(samples), str(owner_id)))
         return len(samples)
 
 
+class _RecordingAuditLog:
+    def __init__(self):
+        self.calls: list[tuple] = []
+
+    async def log_raw(self, session, device_id, raw_payload):
+        self.calls.append(("log_raw", device_id))
+        return 99
+
+    async def mark_processed(self, session, raw_log_id):
+        self.calls.append(("mark_processed", raw_log_id))
+
+
+def _app_with(state_attrs: dict):
+    """Build a fake `request.app` whose `.state` has the given attributes."""
+    state = type("State", (), state_attrs)()
+    return type("App", (), {"state": state})()
+
+
 @pytest.mark.asyncio
-async def test_route_dispatches_through_app_state_storage():
+async def test_route_dispatches_through_app_state_storage_and_audit():
     storage = _RecordingStorage()
+    audit = _RecordingAuditLog()
     session = FakeSession()
     request = FakeRequest(
         {
@@ -86,25 +108,52 @@ async def test_route_dispatches_through_app_state_storage():
             ],
         }
     )
-    request.app = type("App", (), {"state": type("State", (), {"storage": storage})()})()
+    request.app = _app_with({"storage": storage, "audit_log": audit})
 
     result = await server.apple_batch(request, session)
 
     assert result["records"] == 2
-    kinds = [call[0] for call in storage.calls]
-    # Both samples share the "Apple Watch" source -> single device group ->
-    # one ingest call, one mark_processed call.
-    assert kinds == ["device", "log_raw", "ingest", "mark_processed"]
-    ingest_call = next(c for c in storage.calls if c[0] == "ingest")
-    assert ingest_call[1] == "heart_rate"
-    assert ingest_call[2] == 2
+    storage_kinds = [c[0] for c in storage.calls]
+    audit_kinds = [c[0] for c in audit.calls]
+    assert storage_kinds == ["device", "ingest"]
+    assert audit_kinds == ["log_raw", "mark_processed"]
 
 
 @pytest.mark.asyncio
-async def test_recording_storage_satisfies_protocol():
-    """Smoke check: the test backend must be IngestStorage-compatible."""
+async def test_route_skips_audit_when_backend_does_not_provide_one():
+    """InfluxDB-shape: storage present, audit_log explicitly None."""
     storage = _RecordingStorage()
-    assert isinstance(storage, IngestStorage)
+    session = FakeSession()
+    request = FakeRequest(
+        {
+            "metric": "heart_rate",
+            "samples": [{"date": "2026-04-10T12:00:00Z", "qty": 72, "source": "Apple Watch"}],
+        }
+    )
+    request.app = _app_with({"storage": storage, "audit_log": None})
+
+    result = await server.apple_batch(request, session)
+
+    assert result["records"] == 1
+    # Storage still got the writes…
+    assert any(c[0] == "ingest" for c in storage.calls)
+    # …but no SQL audit-log INSERT/UPDATE was issued against the session.
+    raw_inserts = [c for c in session.calls if "raw_ingestion_log" in c[0]]
+    assert raw_inserts == []
+
+
+@pytest.mark.asyncio
+async def test_empty_batch_skips_audit_when_no_audit_backend():
+    storage = _RecordingStorage()
+    session = FakeSession()
+    request = FakeRequest({"metric": "heart_rate", "samples": []})
+    request.app = _app_with({"storage": storage, "audit_log": None})
+
+    result = await server.apple_batch(request, session)
+
+    assert result["status"] == "empty"
+    raw_inserts = [c for c in session.calls if "raw_ingestion_log" in c[0]]
+    assert raw_inserts == []
 
 
 @pytest.mark.asyncio
@@ -118,9 +167,15 @@ async def test_swappable_storage_receives_resolved_owner_id():
         },
         headers={"x-user-id": "11111111-2222-3333-4444-555555555555"},
     )
-    request.app = type("App", (), {"state": type("State", (), {"storage": storage})()})()
+    request.app = _app_with({"storage": storage, "audit_log": None})
 
     await server.apple_batch(request, session)
 
     ingest_call = next(c for c in storage.calls if c[0] == "ingest")
     assert UUID(ingest_call[3]) == UUID("11111111-2222-3333-4444-555555555555")
+
+
+def test_recording_backends_satisfy_their_protocols():
+    """Smoke check that the test doubles match the protocols (Liskov)."""
+    assert isinstance(_RecordingStorage(), IngestStorage)
+    assert isinstance(_RecordingAuditLog(), AuditLog)


### PR DESCRIPTION
Towards #4. Ships the architectural seam without a second backend; the InfluxDB implementation comes in a follow-up PR.

## Why split #4 into two PRs

Putting the protocol abstraction and a working InfluxDB backend in the same diff would mix two concerns:
1. *Refactoring* the existing single-backend code into a pluggable shape (no behavior change, large surface).
2. *Adding* a second backend (real new feature, smaller surface but depends on #1 landing first).

Reviewing the seam in isolation is much easier — if the protocol is wrong, the InfluxDB PR would have to absorb the rework. This PR is a pure refactor; the next one is pure feature.

## What's added

- **`server/ingestion/storage.py`** — `IngestStorage` Protocol with the four operations the ingest route actually uses (`get_or_create_device`, `log_raw_ingestion`, `mark_raw_ingestion_processed`, `ingest_metric`). `PostgresIngestStorage` is the default backend — a thin wrapper around the existing functions in `server/ingestion/handlers.py`. No SQL changes, no behavior change.
- **`server/main.py`** — lifespan stashes a `PostgresIngestStorage` instance on `app.state.storage`. The InfluxDB PR will read `STORAGE_BACKEND` from config and swap the impl here.
- **`server/api/ingest.py`** — reads `request.app.state.storage` with a module-level `default_storage` fall-through for unit tests. The route no longer imports handlers directly.

## What did NOT change

- All SQL: untouched.
- The wire contract for `/api/apple/batch`: unchanged.
- The `/api/apple/status` response shape: unchanged.
- The handlers in `server/ingestion/handlers.py` and `server/ingestion/sleep.py`: unchanged.

## Tests

- 6 new tests in `tests/test_storage_protocol.py`: protocol compliance (`PostgresIngestStorage` and a recording test backend both satisfy `isinstance(_, IngestStorage)`), `default_storage` fallback when no app state, dispatch through `app.state.storage`, and `owner_id` propagation through the seam with the X-User-Id header.
- All 116 pre-existing tests still pass — total 122 passing.

## Quality gates

- `ruff format --check .` clean
- `ruff check .` clean
- `pytest -q` — 122 passed (6 new + 116 existing)

## What ships next (separate PR)

A `feat/influxdb-backend` PR stacked on this one will add `InfluxDBIngestStorage` (using `influxdb-client`), a docker-compose `influxdb` profile, README trade-off docs, and contract tests showing both backends produce equivalent ingestion records.