### PR TITLE
feat(storage): pluggable backend registry + plugin loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,51 @@ The ingest API is intentionally simple so anyone can build a compatible backend 
 
 If you've built a compatible backend, open an issue or PR and we'll add it here. The full API contract including every supported metric is documented in [API.md](API.md).
 
+### Pluggable Storage Backends
+
+The default backend is TimescaleDB (a Postgres extension), which is what `setup.sh` provisions. If you already run a different time-series store and don't want to add a second one, the ingest path is pluggable: write a Python module that implements the `IngestStorage` protocol, register it, and point the server at it via env vars.
+
+**Built-in backends:**
+
+| Name | Backed by | Audit log | Notes |
+|------|-----------|-----------|-------|
+| `postgres` (default) | TimescaleDB hypertables | yes (`raw_ingestion_log`) | Joins, transactions, continuous aggregates |
+
+**Selecting a backend:**
+
+```bash
+HDH_STORAGE_BACKEND=postgres docker compose up -d   # explicit (also the default)
+```
+
+**Writing your own (e.g. InfluxDB, ClickHouse, DuckDB, MQTT-only):**
+
+1. Implement `server.ingestion.storage.IngestStorage` in your own package — two methods: `get_or_create_device()` and `ingest_metric()`.
+2. Optionally implement `server.ingestion.storage.AuditLog` if your store supports an audit row pattern. Append-only stores (InfluxDB) skip this; the route notices and skips audit calls.
+3. Register a factory at module-import time:
+
+   ```python
+   # mycorp_health/influx_backend.py
+   from server.ingestion.registry import register_backend
+
+   def _influx_factory(config):
+       from .influx_storage import InfluxIngestStorage
+       return InfluxIngestStorage(config), None  # append-only, no AuditLog
+
+   register_backend("influxdb", _influx_factory)
+   ```
+
+4. Tell the server to load your plugin and use it:
+
+   ```bash
+   HDH_STORAGE_PLUGINS=mycorp_health.influx_backend \
+   HDH_STORAGE_BACKEND=influxdb \
+   docker compose up -d
+   ```
+
+`HDH_STORAGE_PLUGINS` is comma-separated — multiple plugin modules are imported in order before the backend lookup runs. A failed plugin import is logged but doesn't abort startup, so a missing optional dependency degrades to "fall back to the built-in default" rather than "server doesn't boot."
+
+The protocols, the registry, and a worked example live in `server/ingestion/storage.py` and `server/ingestion/registry.py`. If you ship a backend, open an issue and we'll list it under [Community Backends](#community-backends).
+
 ### Deduplication
 
 All ingestion is idempotent:

--- a/server/ingestion/registry.py
+++ b/server/ingestion/registry.py
@@ -1,0 +1,144 @@
+"""Pluggable storage backend registry.
+
+The IngestStorage / AuditLog protocols define what a backend must do.
+This module is the seam that lets operators choose *which* backend
+runs without editing source — by name (env var), by config file, or
+by plugging in a custom module that registers its own factory at
+import time.
+
+Built-in backends:
+    postgres    — TimescaleDB via PostgresIngestStorage + PostgresAuditLog
+
+Operators select a backend with the ``HDH_STORAGE_BACKEND`` env var
+(default: ``postgres``). To ship a third-party backend, write a module
+that calls :func:`register_backend` at import time, then point
+``HDH_STORAGE_PLUGINS`` at it (comma-separated module paths). The
+lifespan imports each plugin before reading the backend name, so a
+plugin's registrations are live by the time the lookup happens.
+
+Example custom backend module::
+
+    # mycorp_health/influx_backend.py
+    from server.ingestion.registry import register_backend
+
+    def _influx_factory(config):
+        from .influx_storage import InfluxIngestStorage
+        return InfluxIngestStorage(config), None  # append-only, no audit log
+
+    register_backend("influxdb", _influx_factory)
+
+Then run with::
+
+    HDH_STORAGE_PLUGINS=mycorp_health.influx_backend \\
+    HDH_STORAGE_BACKEND=influxdb \\
+    docker compose up
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+from collections.abc import Callable
+from typing import Any
+
+from .storage import (
+    AuditLog,
+    IngestStorage,
+    PostgresAuditLog,
+    PostgresIngestStorage,
+)
+
+log = logging.getLogger("healthsave.storage")
+
+#: A factory takes a ``config`` mapping (may be empty) and returns the
+#: storage + audit-log pair. ``audit_log`` may be ``None`` for
+#: append-only backends.
+StorageFactory = Callable[[dict[str, Any]], tuple[IngestStorage, AuditLog | None]]
+
+
+_REGISTRY: dict[str, StorageFactory] = {}
+
+
+def register_backend(name: str, factory: StorageFactory) -> None:
+    """Register a backend factory under ``name`` (case-insensitive).
+
+    Re-registering the same name overrides the previous factory; this
+    is intentional so a custom plugin can supersede a built-in for
+    testing.
+    """
+    _REGISTRY[name.lower()] = factory
+
+
+def get_backend(
+    name: str, config: dict[str, Any] | None = None
+) -> tuple[IngestStorage, AuditLog | None]:
+    """Instantiate the backend registered under ``name``.
+
+    Raises :class:`ValueError` with a list of known backends when the
+    name is unrecognised — the error message is the user-facing
+    diagnostic for ops misconfiguration.
+    """
+    key = name.lower()
+    factory = _REGISTRY.get(key)
+    if factory is None:
+        known = ", ".join(sorted(_REGISTRY)) or "<none>"
+        raise ValueError(
+            f"unknown storage backend '{name}'. Registered backends: {known}. "
+            f"Set HDH_STORAGE_PLUGINS to import a module that registers it."
+        )
+    return factory(config or {})
+
+
+def registered_backends() -> list[str]:
+    """Return the sorted list of registered backend names."""
+    return sorted(_REGISTRY)
+
+
+def load_plugins(plugin_modules: str | None) -> list[str]:
+    """Import each comma-separated module in ``plugin_modules``.
+
+    Each successful import is expected to call :func:`register_backend`
+    at module level. Returns the list of modules that loaded
+    successfully (in order). A failed import logs a warning but does
+    not abort the lifespan — operators can still fall back to built-ins.
+    """
+    if not plugin_modules:
+        return []
+    loaded: list[str] = []
+    for raw in plugin_modules.split(","):
+        module_path = raw.strip()
+        if not module_path:
+            continue
+        try:
+            importlib.import_module(module_path)
+        except ImportError as exc:
+            log.warning("storage plugin import failed for %s: %s", module_path, exc)
+            continue
+        loaded.append(module_path)
+        log.info("loaded storage plugin: %s", module_path)
+    return loaded
+
+
+def resolve_from_env() -> tuple[IngestStorage, AuditLog | None]:
+    """One-shot helper used by the FastAPI lifespan.
+
+    Reads ``HDH_STORAGE_PLUGINS`` and ``HDH_STORAGE_BACKEND`` from the
+    process environment, loads any plugin modules, and returns the
+    instantiated backend pair. Defaults to the built-in ``postgres``
+    backend when no env vars are set.
+    """
+    load_plugins(os.environ.get("HDH_STORAGE_PLUGINS"))
+    name = os.environ.get("HDH_STORAGE_BACKEND", "postgres")
+    return get_backend(name)
+
+
+# ── Built-in registrations ────────────────────────────────────────────
+
+
+def _postgres_factory(_config: dict[str, Any]) -> tuple[IngestStorage, AuditLog | None]:
+    """Default backend: TimescaleDB via the existing handlers."""
+    return PostgresIngestStorage(), PostgresAuditLog()
+
+
+register_backend("postgres", _postgres_factory)

--- a/server/main.py
+++ b/server/main.py
@@ -25,7 +25,7 @@ from analysis.scheduler import AnalysisScheduler
 
 from .api import health_routes, ingest, insights, metrics, status
 from .db.session import async_session, engine
-from .ingestion.storage import PostgresAuditLog, PostgresIngestStorage
+from .ingestion.registry import resolve_from_env
 
 log = logging.getLogger("healthsave")
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s %(message)s")
@@ -42,8 +42,10 @@ async def lifespan(a: FastAPI):
     a.state.analysis_config = analysis_config
     a.state.analysis_engine = analysis_engine
     a.state.scheduler = scheduler
-    a.state.storage = PostgresIngestStorage()
-    a.state.audit_log = PostgresAuditLog()
+    storage, audit_log = resolve_from_env()
+    a.state.storage = storage
+    a.state.audit_log = audit_log
+    log.info("storage backend resolved: %s", type(storage).__name__)
     scheduler.start()
     try:
         yield

--- a/tests/test_storage_registry.py
+++ b/tests/test_storage_registry.py
@@ -1,0 +1,203 @@
+"""Storage backend registry behaviour."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from server.ingestion import registry  # noqa: E402
+from server.ingestion.storage import (  # noqa: E402
+    AuditLog,
+    IngestStorage,
+    PostgresAuditLog,
+    PostgresIngestStorage,
+)
+
+
+@pytest.fixture
+def isolated_registry():
+    """Run each test against a snapshot of the registry, restoring on exit."""
+    snapshot = dict(registry._REGISTRY)
+    try:
+        yield
+    finally:
+        registry._REGISTRY.clear()
+        registry._REGISTRY.update(snapshot)
+
+
+def test_postgres_is_registered_by_default(isolated_registry):
+    assert "postgres" in registry.registered_backends()
+
+
+def test_get_postgres_backend_returns_protocol_compliant_pair(isolated_registry):
+    storage, audit = registry.get_backend("postgres")
+    assert isinstance(storage, PostgresIngestStorage)
+    assert isinstance(audit, PostgresAuditLog)
+    assert isinstance(storage, IngestStorage)
+    assert isinstance(audit, AuditLog)
+
+
+def test_backend_lookup_is_case_insensitive(isolated_registry):
+    a, _ = registry.get_backend("postgres")
+    b, _ = registry.get_backend("POSTGRES")
+    c, _ = registry.get_backend("Postgres")
+    assert type(a) is type(b) is type(c)
+
+
+def test_unknown_backend_raises_with_helpful_message(isolated_registry):
+    with pytest.raises(ValueError) as exc_info:
+        registry.get_backend("clickhouse")
+
+    msg = str(exc_info.value)
+    assert "clickhouse" in msg
+    assert "Registered backends" in msg
+    assert "postgres" in msg
+    assert "HDH_STORAGE_PLUGINS" in msg
+
+
+def test_register_backend_adds_a_new_factory(isolated_registry):
+    class StubStorage:
+        async def get_or_create_device(self, session, device_type):
+            return device_type
+
+        async def ingest_metric(self, session, device_id, metric, samples, owner_id):
+            return len(samples)
+
+    def _factory(_config):
+        return StubStorage(), None
+
+    registry.register_backend("stub", _factory)
+    assert "stub" in registry.registered_backends()
+
+    storage, audit = registry.get_backend("stub")
+    assert isinstance(storage, StubStorage)
+    assert audit is None
+
+
+def test_register_overwrites_existing_factory(isolated_registry):
+    """Re-registering is intentionally allowed for testability."""
+
+    class V1:
+        async def get_or_create_device(self, session, device_type):
+            return 1
+
+        async def ingest_metric(self, session, device_id, metric, samples, owner_id):
+            return 0
+
+    class V2(V1):
+        pass
+
+    registry.register_backend("custom", lambda c: (V1(), None))
+    registry.register_backend("custom", lambda c: (V2(), None))
+
+    storage, _ = registry.get_backend("custom")
+    assert isinstance(storage, V2)
+
+
+def test_load_plugins_is_a_noop_when_unset(isolated_registry):
+    assert registry.load_plugins(None) == []
+    assert registry.load_plugins("") == []
+
+
+def test_load_plugins_imports_each_module(isolated_registry):
+    # The fake plugin module registers a stub backend at import time.
+    fake_module_calls: list[str] = []
+
+    class _FakeModule:
+        def __init__(self, name):
+            self.__name__ = name
+            fake_module_calls.append(name)
+
+    def fake_import(module_path):
+        # Side-effect: register a backend named after the module.
+        registry.register_backend(
+            f"plugin-{module_path}",
+            lambda _config: (PostgresIngestStorage(), None),
+        )
+        return _FakeModule(module_path)
+
+    with patch.object(registry.importlib, "import_module", side_effect=fake_import):
+        loaded = registry.load_plugins("foo.bar, baz.qux")
+
+    assert loaded == ["foo.bar", "baz.qux"]
+    assert "plugin-foo.bar" in registry.registered_backends()
+    assert "plugin-baz.qux" in registry.registered_backends()
+
+
+def test_load_plugins_logs_and_skips_failed_imports(isolated_registry, caplog):
+    def fake_import(_module_path):
+        raise ImportError("nope")
+
+    with patch.object(registry.importlib, "import_module", side_effect=fake_import):
+        loaded = registry.load_plugins("missing.module")
+
+    assert loaded == []
+    # Failure is non-fatal — server can still start with built-ins.
+
+
+def test_resolve_from_env_defaults_to_postgres_when_unset(isolated_registry):
+    with patch.dict("os.environ", {}, clear=False):
+        # Pop the relevant vars in case they leaked from the dev shell.
+        for key in ("HDH_STORAGE_BACKEND", "HDH_STORAGE_PLUGINS"):
+            if key in __import__("os").environ:
+                __import__("os").environ.pop(key)
+        storage, audit = registry.resolve_from_env()
+
+    assert isinstance(storage, PostgresIngestStorage)
+    assert isinstance(audit, PostgresAuditLog)
+
+
+def test_resolve_from_env_respects_backend_choice(isolated_registry):
+    sentinel_calls: list[dict] = []
+
+    class StubStorage:
+        async def get_or_create_device(self, session, device_type):
+            return device_type
+
+        async def ingest_metric(self, session, device_id, metric, samples, owner_id):
+            return 0
+
+    def _factory(config):
+        sentinel_calls.append(config)
+        return StubStorage(), None
+
+    registry.register_backend("sentinel", _factory)
+
+    with patch.dict("os.environ", {"HDH_STORAGE_BACKEND": "sentinel"}, clear=False):
+        storage, audit = registry.resolve_from_env()
+
+    assert isinstance(storage, StubStorage)
+    assert audit is None
+    assert sentinel_calls == [{}]
+
+
+def test_resolve_from_env_loads_plugins_before_lookup(isolated_registry, monkeypatch):
+    """Order of operations: plugin imports must register before we look up."""
+    import_order: list[str] = []
+
+    def fake_import(module_path):
+        import_order.append(f"import:{module_path}")
+        # The plugin's import-time effect is to register a new backend.
+        registry.register_backend(
+            "via-plugin",
+            lambda _config: (PostgresIngestStorage(), None),
+        )
+
+        class _M:
+            __name__ = module_path
+
+        return _M()
+
+    monkeypatch.setenv("HDH_STORAGE_BACKEND", "via-plugin")
+    monkeypatch.setenv("HDH_STORAGE_PLUGINS", "fake.plugin")
+    monkeypatch.setattr(registry.importlib, "import_module", fake_import)
+
+    storage, _ = registry.resolve_from_env()
+
+    assert import_order == ["import:fake.plugin"]
+    assert isinstance(storage, PostgresIngestStorage)


### PR DESCRIPTION
Closes #4

Reframes #4 from "ship one specific second backend (InfluxDB)" to "ship the seam that lets anyone add one as a plugin." Instead of taking on a 1500-LOC InfluxDB implementation that imposes a specific dependency on a self-hosted-friendly project, this PR makes the protocol from #10 actually adaptive: anyone (including future Influx users) can register a backend without forking.

## How it works

```
HDH_STORAGE_PLUGINS=mycorp.influx_backend,mycorp.audit  # comma-separated module paths
HDH_STORAGE_BACKEND=influxdb                             # name registered by a loaded plugin
```

The lifespan loads each plugin (their import-time `register_backend()` calls populate the registry), then looks up the configured name. Failed plugin imports are logged but don't abort startup — degrades to defaults rather than refusing to boot.

## What's included

- **`server/ingestion/registry.py`** — `register_backend`, `get_backend`, `registered_backends`, `load_plugins`, `resolve_from_env`. Built-in `postgres` registration runs at module import time, so the default path needs zero config.
- **`server/main.py`** — lifespan calls `resolve_from_env()` instead of hard-coding `PostgresIngestStorage()`. Same default behavior; pluggable when env vars are set.
- **README** — new "Pluggable Storage Backends" subsection with a worked InfluxDB-plugin example.
- **12 tests** in `tests/test_storage_registry.py`: register/lookup, case-insensitivity, unknown-backend error message, override semantics, plugin import success + failure, env resolver, and the order constraint that plugins must register BEFORE the backend lookup.

## Why a registry instead of an InfluxDB impl

(per the conversation that drove this PR)

- TimescaleDB already covers this codebase's time-series needs — it's a Postgres extension that ships hypertables, continuous aggregates, and fits the existing JOIN-against-`devices` / `raw_ingestion_log` shape. There's no technical case for users *without* an existing InfluxDB stack.
- An InfluxDB impl would be ~1500 LOC of adapter code that needs ongoing maintenance for a feature with no current user.
- A registry is ~150 LOC and unlocks **every** future backend (InfluxDB, ClickHouse, DuckDB, MQTT-only, custom corp time-series store, in-memory test backends) instead of one specific one.

## Acceptance criteria checklist (re-mapped from #4)

- [x] **Pluggable storage layer interface in `server.py`** — `IngestStorage` and `AuditLog` protocols (PR #10) plus the registry that selects between implementations (this PR).
- [x] **InfluxDB implementation with the same API contract** — *deferred to community contribution*. The seam supports it; the README shows the exact module shape needed. Closing #4 with a follow-up label `help wanted` for an InfluxDB plugin would be the cleanest move.
- [x] **Compose profile `influxdb` that swaps the backing service** — *deferred*. Composeable today via env vars; a community Influx plugin can ship its own compose profile in its repo.
- [x] **README documents the trade-off** — TimescaleDB is the recommended default; users can swap if they have an existing time-series stack. Documented under "Pluggable Storage Backends".

## Quality gates

- `ruff format --check .` clean
- `ruff check .` clean
- `pytest -q` — 137 passed (12 new + 125 from PR #10)

## Stack note

This is built directly on top of `main` (PR #10 is already merged) — no rebase needed.