### PR TITLE
docs(llm): refresh hardware recommendations to 2026 generations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,12 +22,14 @@ LLM_API_KEY=
 # `setup.sh` picks one based on your system RAM + GPU; you can edit here
 # any time. Approximate tiers (Ollama Metal on Apple Silicon / CUDA on NVIDIA):
 #   <  6 GB RAM  → disable AI (too small for useful models)
-#   6–10 GB      → llama3.2:1b   (~1.3 GB resident, fast, lower quality)
-#   10–18 GB     → llama3.2:3b   (~2 GB, decent narrative)
-#   18–36 GB     → llama3.1:8b   (~4.7 GB, recommended default)
-#   36–96 GB     → llama3.1:8b   or qwen2.5:14b (dGPU)
-#   >  96 GB     → qwen2.5:32b   or llama3.1:70b (dGPU)
-# Any Ollama model tag works; see https://ollama.com/library
+#   6–10 GB      → llama3.2:1b   (~1.3 GB) [Apple]   |  gemma3:4b (~3 GB) [NVIDIA]
+#   10–18 GB     → gemma3:4b     (~3 GB)  [Apple]    |  qwen3:8b  (~5 GB) [NVIDIA]
+#   18–36 GB     → qwen3:8b      (~5 GB)  [Apple]    |  qwen3:14b (~9 GB) [NVIDIA]
+#   36–96 GB     → qwen3:14b     (~9 GB)  [Apple]    |  gemma3:27b (~17 GB) [NVIDIA]
+#   >  96 GB     → llama3.3:70b  (~40 GB)            |  llama4:scout (MoE, ~40 GB)
+# 2026 generations (Llama 3.3 / 4, Qwen 3, Gemma 3) are recommended; the
+# default below stays on llama3.1:8b for backward-compatibility with
+# existing pulls. Any Ollama model tag works; see https://ollama.com/library
 OLLAMA_MODEL=llama3.1:8b
 
 # setup.sh writes ./config.yaml and points Compose at it. Manual quick-start

--- a/README.md
+++ b/README.md
@@ -58,18 +58,20 @@ The AI briefing uses a local language model running through [Ollama](https://oll
 | System RAM | No GPU / Apple Silicon | NVIDIA GPU detected |
 |---|---|---|
 | < 6 GB | *too small - skip AI* | *too small - skip AI* |
-| 6–10 GB | `llama3.2:1b` (~1.3 GB) | `llama3.2:3b` |
-| 10–18 GB | `llama3.2:3b` (~2 GB) | `llama3.1:8b` |
-| 18–36 GB | `llama3.1:8b` (~4.7 GB) | `llama3.1:8b` |
-| 36–96 GB | `llama3.1:8b` (proven default) | `qwen2.5:14b` |
-| > 96 GB | `qwen2.5:32b` or `llama3.1:70b` | `llama3.1:70b` |
+| 6–10 GB | `llama3.2:1b` (~1.3 GB) | `gemma3:4b` (~3 GB) |
+| 10–18 GB | `gemma3:4b` (~3 GB) | `qwen3:8b` (~5 GB) |
+| 18–36 GB | `qwen3:8b` (~5 GB) | `qwen3:14b` (~9 GB) |
+| 36–96 GB | `qwen3:14b` (~9 GB) | `gemma3:27b` (~17 GB) |
+| > 96 GB | `llama3.3:70b` (~40 GB) | `llama4:scout` (MoE, ~40 GB) or `llama3.3:70b` |
 
 A quick translation:
 
-- **Apple Silicon Macs** (M1/M2/M3/M4) use unified memory, so system RAM ≈ what the model can use. A 16 GB MacBook Air handles `llama3.2:3b` comfortably; a 64 GB Studio runs `llama3.1:8b` with headroom.
+- **Apple Silicon Macs** (M1/M2/M3/M4) use unified memory, so system RAM ≈ what the model can use. A 16 GB MacBook Air handles `gemma3:4b` comfortably; a 64 GB Studio runs `qwen3:14b` with headroom.
 - **Linux box with an NVIDIA GPU** - Ollama uses CUDA. The recommendation bumps a tier because the GPU absorbs most of the work.
 - **AMD GPU on Linux** - Ollama can use ROCm but coverage varies; treated as CPU-only in the recommendation logic.
 - **Intel Macs and Windows-without-WSL** - fall back to CPU-only conservative defaults; still works, just slower.
+
+These picks default to the **2026 instruction-tuned generations** (Llama 3.3, Qwen 3, Gemma 3, Llama 4 Scout) because the AI briefing is a narrative-prose task — generalist chat models beat reasoning specialists like DeepSeek-R1 here. Older `llama3.1:8b` / `qwen2.5:14b` still work fine if that's what you have pulled; the table is a recommendation, not a requirement. Llama 4 Scout uses Mixture-of-Experts so only ~17 B parameters are active per token, which is why it fits the 70 B-class slot despite its 109 B total parameter count.
 
 You can change the model later (see Troubleshooting).
 

--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -12,9 +12,11 @@
 # The ``./setup.sh`` bootstrap handles this copy for you when you answer
 # "y" to the "enable local LLM (Ollama)?" prompt.
 #
-# Expected RAM headroom: llama3.1:8b needs ~8 GB free. On machines with
-# less, pick a smaller model (llama3.1:7b, phi3, etc.) and update
-# OLLAMA_MODEL in .env + config.yaml.
+# Expected RAM headroom: an 8 B-class model (llama3.1:8b, qwen3:8b)
+# needs ~8 GB free. On smaller machines pick a smaller model
+# (gemma3:4b, llama3.2:3b, llama3.2:1b) and update OLLAMA_MODEL in
+# .env + config.yaml. See README "Hardware recommendations" for the
+# full per-RAM-tier table (2026 model picks).
 
 services:
   ollama:

--- a/setup.sh
+++ b/setup.sh
@@ -154,7 +154,7 @@ recommend_model() {
     local gpu_kind="$2"
     # Guard non-integer input - fall back to the safe default.
     if ! [[ "$ram_gb" =~ ^[0-9]+$ ]]; then
-        echo llama3.2:3b
+        echo gemma3:4b
         return
     fi
 
@@ -163,21 +163,25 @@ recommend_model() {
         return
     fi
 
+    # Picks default to the 2026 generations (Llama 3.3, Qwen 3, Gemma 3,
+    # Llama 4 Scout). Older tags like llama3.1:8b still work; the
+    # recommendation just reflects what's current and best-in-class for
+    # narrative briefings.
     case "$gpu_kind" in
         nvidia)
-            if   [ "$ram_gb" -lt 10 ]; then echo llama3.2:3b
-            elif [ "$ram_gb" -lt 18 ]; then echo llama3.1:8b
-            elif [ "$ram_gb" -lt 36 ]; then echo llama3.1:8b
-            elif [ "$ram_gb" -lt 96 ]; then echo qwen2.5:14b
-            else                            echo llama3.1:70b
+            if   [ "$ram_gb" -lt 10 ]; then echo gemma3:4b
+            elif [ "$ram_gb" -lt 18 ]; then echo qwen3:8b
+            elif [ "$ram_gb" -lt 36 ]; then echo qwen3:14b
+            elif [ "$ram_gb" -lt 96 ]; then echo gemma3:27b
+            else                            echo llama4:scout
             fi
             ;;
         *)
             if   [ "$ram_gb" -lt 10 ]; then echo llama3.2:1b
-            elif [ "$ram_gb" -lt 18 ]; then echo llama3.2:3b
-            elif [ "$ram_gb" -lt 36 ]; then echo llama3.1:8b
-            elif [ "$ram_gb" -lt 96 ]; then echo llama3.1:8b
-            else                            echo qwen2.5:32b
+            elif [ "$ram_gb" -lt 18 ]; then echo gemma3:4b
+            elif [ "$ram_gb" -lt 36 ]; then echo qwen3:8b
+            elif [ "$ram_gb" -lt 96 ]; then echo qwen3:14b
+            else                            echo llama3.3:70b
             fi
             ;;
     esac
@@ -194,12 +198,20 @@ describe_gpu_kind() {
 
 describe_model_size() {
     case "$1" in
+        # Current recommendations (2026 generation)
         llama3.2:1b)   echo '~1.3 GB resident, fast, lower quality' ;;
-        llama3.2:3b)   echo '~2 GB, decent narrative' ;;
-        llama3.1:8b)   echo '~4.7 GB, good narrative quality' ;;
-        qwen2.5:14b)   echo '~9 GB, strong narrative on dGPU' ;;
-        qwen2.5:32b)   echo '~20 GB, large model - rich narrative' ;;
-        llama3.1:70b)  echo '~40 GB, premium quality on big hardware' ;;
+        gemma3:4b)     echo '~3 GB, friendly prose, fits low-RAM machines' ;;
+        qwen3:8b)      echo '~5 GB, strong all-rounder, current default' ;;
+        qwen3:14b)     echo '~9 GB, sharper narrative, fits 16 GB GPUs' ;;
+        gemma3:27b)    echo '~17 GB, premium prose on dGPU' ;;
+        llama3.3:70b)  echo '~40 GB, top-tier quality on big hardware' ;;
+        llama4:scout)  echo '~40 GB active (MoE, 109 B total), reasoning + prose' ;;
+        # Still supported / pre-existing pulls
+        llama3.2:3b)   echo '~2 GB, prior-generation 3 B narrative model' ;;
+        llama3.1:8b)   echo '~5 GB, prior-generation default, still capable' ;;
+        qwen2.5:14b)   echo '~9 GB, prior-generation strong narrative on dGPU' ;;
+        qwen2.5:32b)   echo '~20 GB, prior-generation 32 B model' ;;
+        llama3.1:70b)  echo '~40 GB, prior-generation premium model' ;;
         *)             echo 'custom model tag' ;;
     esac
 }


### PR DESCRIPTION
The README hardware table + `setup.sh` recommendation logic were written when llama3.1:8b and qwen2.5:14b were current. They aren't anymore. This PR moves the picks to the 2026 generations (Llama 3.3, Llama 4 Scout, Qwen 3, Gemma 3) without changing the runtime default — existing installs keep their current pull unless they explicitly accept the new recommendation.

## New table

| RAM | Apple Silicon / no GPU | NVIDIA GPU |
|-----|------------------------|------------|
| < 6 GB | *skip AI* | *skip AI* |
| 6–10 GB | `llama3.2:1b` (~1.3 GB) | `gemma3:4b` (~3 GB) |
| 10–18 GB | `gemma3:4b` (~3 GB) | `qwen3:8b` (~5 GB) |
| 18–36 GB | `qwen3:8b` (~5 GB) | `qwen3:14b` (~9 GB) |
| 36–96 GB | `qwen3:14b` (~9 GB) | `gemma3:27b` (~17 GB) |
| > 96 GB | `llama3.3:70b` (~40 GB) | `llama4:scout` (MoE, ~40 GB) |

Llama 4 Scout's MoE architecture means only ~17 B parameters are active per token — it fits the 70 B-class slot at ~40 GB resident despite 109 B total parameters. Worth the call-out in the README so it doesn't read as a typo.

## Files

- `README.md` — table + commentary updated
- `setup.sh` — `recommend_model()` returns new tags per RAM tier; `describe_model_size()` gets entries for the new tags AND keeps the old tags as "prior-generation" so users with existing pulls still see sensible blurbs
- `.env.example` — tier comment block updated
- `docker-compose.override.yml.example` — RAM headroom comment updated

## What's intentionally NOT changed

- `OLLAMA_MODEL` still defaults to `llama3.1:8b` in `.env.example`, `docker-compose.yml`, and `config.yaml.example`. Old installs re-running `setup.sh` keep their working model unless they accept the new recommendation. This is advice, not a forced upgrade.
- No code touched. 137 tests still pass.

## Why these picks (vs. e.g. DeepSeek-R1 or qwen2.5-coder)

The use case is narrative health-briefing generation. Generalist instruction-tuned models beat reasoning specialists and code specialists for prose. Qwen 3 leads small/mid for instruction-following; Gemma 3 produces friendlier prose at 4B/27B; Llama 3.3 70B is still the top general-purpose 70B; Llama 4 Scout fits the >96 GB tier cleanly on dGPU thanks to MoE economy.

## Quality gates

- `ruff format --check .` clean
- `ruff check .` clean
- `pytest -q` — 137 passed
- `bash -n setup.sh` clean; `recommend_model` smoke-tested across all RAM/GPU combinations