### PR TITLE
fix(normalization): route activity_summaries through canonical observations

### DIFF
--- a/contracts/parity.json
+++ b/contracts/parity.json
@@ -962,6 +962,12 @@
       "ios": "available",
       "android": "planned",
       "planned_since": "2026-06-10"
+    },
+    "activity_summaries": {
+      "ios": "available",
+      "android": "planned",
+      "planned_since": "2026-06-10",
+      "note": "Bundled iOS activity-ring summary (active_energy_burned + apple_exercise_time fields); expanded into per-metric canonical observations by the normalizer, not stored under this wire name."
     }
   },
   "features": {

--- a/packages/py/normalization/apple.py
+++ b/packages/py/normalization/apple.py
@@ -24,7 +24,34 @@ from .fusion import exact_ingest_key as build_exact_ingest_key
 from .parsers import sample_device_name
 
 NORMALIZER_ID = "apple_health"
-NORMALIZER_VERSION = "0.3.0"
+NORMALIZER_VERSION = "0.4.0"
+
+# HealthSave's iOS client sends the daily activity-ring totals bundled into a
+# single wire metric ("activity_summaries") rather than as per-metric quantity
+# batches (the shape every other wire metric — including the *same* totals
+# sent individually, e.g. `active_energy_burned` — uses). Because
+# `_apple_wire_index()` only indexes source_metric names declared on
+# individual MetricDefinitions, "activity_summaries" itself never resolves to
+# a canonical metric, so `normalize_apple_batch` silently produced zero
+# observations for it (BUG-2026-08: dual-write divergence, canonical_accepted
+# always 0 while the daily_activity projection kept writing correctly).
+#
+# Fix: unpack each activity_summaries sample into its constituent wire-metric
+# fields and re-run them through the normal per-metric path below, so they
+# land in canonical_observations exactly like a standalone quantity batch for
+# the same wire name would.
+_ACTIVITY_SUMMARY_WIRE = "activity_summaries"
+# Only fields whose HealthKit semantics match the canonical metric's unit
+# 1:1 are auto-expanded here. `appleStandHours` is a 0-24 COUNT of hours with
+# any standing activity (matches the iOS Activity ring's "Stand" number), not
+# a minutes total — mapping it straight into `activity.stand_minutes` (unit
+# "min") would silently corrupt the value (e.g. reporting 9 hours as "9 min
+# stood"). That needs its own canonical metric/ontology fix, not a blind
+# field rename, so it is intentionally left unmapped here.
+_ACTIVITY_SUMMARY_FIELD_TO_WIRE_METRIC: dict[str, str] = {
+    "activeEnergyBurned": "active_energy_burned",
+    "appleExerciseTime": "apple_exercise_time",
+}
 
 _HEALTHKIT_STATISTICS_ORIGIN = "HealthKit Statistics"
 _HEALTHKIT_STATISTICS_ORIGIN_KEY = identity.normalize_origin(_HEALTHKIT_STATISTICS_ORIGIN)
@@ -313,6 +340,34 @@ def _normalize_sample(
     )
 
 
+def _expand_activity_summary_sample(sample: dict[str, Any]) -> list[tuple[str, dict[str, Any]]]:
+    """Split one activity_summaries sample into (wire_metric, single-field sample) pairs.
+
+    Each HealthKit "*Goal" companion field and unrecognized keys are dropped —
+    they carry no canonical metric of their own. The date/source keys are
+    preserved on every derived sample so ``_normalize_sample`` sees the same
+    timestamp/origin it would for a standalone quantity batch.
+
+    The bundled activity summary is HealthKit's own deduplicated, all-source
+    daily rollup (identical in kind to the `step_count`/`active_energy_burned`
+    batches the client sends tagged ``source: "HealthKit Statistics"``), but
+    the summary payload omits that source tag. We stamp it on so the derived
+    samples take the stable daily-total identity path in ``_normalize_sample``
+    — otherwise a later sync that revises the day's total would append a second
+    observation instead of replacing the first (value_repr-based dedup_key).
+    """
+    shared_keys = {*_TIME_KEYS, *_END_KEYS, "source", "sourceName", "device", "deviceName"}
+    shared = {key: value for key, value in sample.items() if key in shared_keys}
+    if not any(shared.get(k) for k in ("source", "sourceName", "device", "deviceName")):
+        shared["source"] = _HEALTHKIT_STATISTICS_ORIGIN
+    expanded: list[tuple[str, dict[str, Any]]] = []
+    for field_name, wire_metric in _ACTIVITY_SUMMARY_FIELD_TO_WIRE_METRIC.items():
+        if sample.get(field_name) is None:
+            continue
+        expanded.append((wire_metric, {**shared, "qty": sample[field_name]}))
+    return expanded
+
+
 def normalize_apple_batch(
     payload: dict[str, Any],
     *,
@@ -328,6 +383,43 @@ def normalize_apple_batch(
     payload = payload or {}
     wire = payload.get("metric")
     samples = payload.get("samples") or []
+
+    # activity_summaries bundles several daily totals into one sample per day
+    # instead of one wire metric per field; unpack before the normal single-
+    # metric routing below so each total still resolves to its own canonical
+    # metric (see _ACTIVITY_SUMMARY_FIELD_TO_WIRE_METRIC for why this exists).
+    if wire == _ACTIVITY_SUMMARY_WIRE:
+        for sample in samples:
+            if not isinstance(sample, dict):
+                result.rejections.append(Rejection("sample_not_object", {"raw": sample}))
+                continue
+            derived = _expand_activity_summary_sample(sample)
+            if not derived:
+                result.rejections.append(Rejection("activity_summary_no_known_fields", sample))
+                continue
+            for wire_metric, derived_sample in derived:
+                metric = _WIRE_INDEX.get(wire_metric)
+                if metric is None:
+                    result.rejections.append(
+                        Rejection(f"unmapped_metric:{wire_metric}", derived_sample)
+                    )
+                    continue
+                outcome = _normalize_sample(
+                    derived_sample,
+                    metric,
+                    source_id=source_id,
+                    provenance=provenance,
+                    owner_id=owner_id,
+                    workspace_id=workspace_id,
+                    device_id=device_id,
+                    raw_payload_id=raw_payload_id,
+                )
+                if isinstance(outcome, Rejection):
+                    result.rejections.append(outcome)
+                else:
+                    result.observations.append(outcome)
+        return result
+
     metric = _WIRE_INDEX.get(wire) if isinstance(wire, str) else None
 
     if metric is None:

--- a/tests/contract/v2/test_v2_meta.py
+++ b/tests/contract/v2/test_v2_meta.py
@@ -35,7 +35,7 @@ async def test_meta_normalizer_version_reflects_the_live_normalizer() -> None:
     body = await v2_meta()
     # PRODUCT-002: the canonical normalizer runs on every batch, so this axis
     # must reflect the real version, not "0"/"no normalizer yet".
-    assert NORMALIZER_VERSION == "0.3.0"
+    assert NORMALIZER_VERSION == "0.4.0"
     assert body["versions"]["normalizer"] == NORMALIZER_VERSION
     assert body["versions"]["normalizer"] != "0"
 

--- a/tests/fixtures/apple_healthsave/activity_summaries_batch.json
+++ b/tests/fixtures/apple_healthsave/activity_summaries_batch.json
@@ -1,0 +1,16 @@
+{
+  "metric": "activity_summaries",
+  "batch_index": 0,
+  "total_batches": 1,
+  "samples": [
+    {
+      "date": "2026-08-21T22:00:00.000Z",
+      "appleStandHours": 9,
+      "appleExerciseTime": 94,
+      "activeEnergyBurned": 956.3371289361303,
+      "appleStandHoursGoal": 12,
+      "appleExerciseTimeGoal": 30,
+      "activeEnergyBurnedGoal": 700
+    }
+  ]
+}

--- a/tests/fixtures/apple_healthsave_responses/batch_receipt_activity_summaries.json
+++ b/tests/fixtures/apple_healthsave_responses/batch_receipt_activity_summaries.json
@@ -1,0 +1,43 @@
+{
+  "body": {
+    "batch": 0,
+    "batch_id": "corpus-activity_summaries-000",
+    "batch_index": 0,
+    "idempotency_key": "corpus-activity_summaries-000",
+    "metric": "activity_summaries",
+    "per_metric": {
+      "activity_summaries": {
+        "accepted": 1,
+        "deduped_existing": null,
+        "deduped_in_batch": 1,
+        "inserted_new": null,
+        "received": 1,
+        "rejected": 0,
+        "sample_window": {
+          "max_sample_time": "2026-01-01T06:00:00Z",
+          "min_sample_time": "2026-01-01T00:00:00Z"
+        }
+      }
+    },
+    "receipt_id": "corpus-activity_summaries-000",
+    "records": 1,
+    "records_accepted": 1,
+    "records_deduped_existing": null,
+    "records_deduped_in_batch": 1,
+    "records_inserted_new": null,
+    "records_received": 1,
+    "records_rejected": 0,
+    "sample_window": {
+      "max_sample_time": "2026-01-01T06:00:00Z",
+      "min_sample_time": "2026-01-01T00:00:00Z"
+    },
+    "status": "processed",
+    "storage_result_level": "accepted_only",
+    "sync_run_id": "corpus-run-001",
+    "total_batches": 1,
+    "verification_level": "delivery_receipt"
+  },
+  "endpoint": "/api/apple/batch",
+  "method": "POST",
+  "status": 200
+}

--- a/tests/test_apple_normalizer.py
+++ b/tests/test_apple_normalizer.py
@@ -213,3 +213,53 @@ def test_unmapped_metric_rejects_every_sample() -> None:
     assert res.accepted == 0
     assert res.rejected == 1
     assert res.rejections[0].reason.startswith("unmapped_metric")
+
+
+def test_activity_summaries_batch_expands_into_per_metric_observations() -> None:
+    # Regression: the iOS client bundles daily activity-ring totals into a
+    # single "activity_summaries" wire metric. That name has no source mapping,
+    # so the normalizer used to emit zero canonical observations for it (the
+    # dual-write divergence: canonical_accepted=0 while daily_activity wrote
+    # fine), leaving Active Energy / Exercise Minutes stuck on "waiting".
+    res = _run("activity_summaries_batch.json")
+    by_metric = {o.metric_id: o for o in res.observations}
+    # Active Energy (kcal) and Exercise Minutes (min) expand 1:1; Stand Hours
+    # is deliberately NOT mapped (it's a 0-24 hour count, not minutes).
+    assert "activity.active_energy" in by_metric
+    assert "activity.exercise_minutes" in by_metric
+    assert "activity.stand_minutes" not in by_metric
+    assert by_metric["activity.active_energy"].value.value == 956.3371289361303
+    assert by_metric["activity.active_energy"].value.canonical_unit == "kcal"
+    assert by_metric["activity.exercise_minutes"].value.value == 94.0
+    assert by_metric["activity.exercise_minutes"].value.canonical_unit == "min"
+    # HealthKit daily-total identity: stamped source routes both through the
+    # stable owner-all-source-day-total dedup path so a later same-day revision
+    # replaces rather than appends.
+    for obs in res.observations:
+        assert obs.aggregation_scope == "owner_all_source_day_total"
+        assert obs.exact_ingest_key is not None
+
+
+def test_activity_summaries_same_day_revision_keeps_stable_identity() -> None:
+    def normalize(active_energy: float):
+        result = normalize_apple_batch(
+            {
+                "metric": "activity_summaries",
+                "samples": [
+                    {
+                        "date": "2026-08-21T22:00:00.000Z",
+                        "activeEnergyBurned": active_energy,
+                        "appleExerciseTime": 94,
+                    }
+                ],
+            },
+            source_id=_SOURCE,
+            provenance=_PROV,
+        )
+        return {o.metric_id: o for o in result.observations}
+
+    first = normalize(956.3)["activity.active_energy"]
+    revised = normalize(1012.7)["activity.active_energy"]
+    # Same calendar day → same upsert identity even though the value changed.
+    assert first.dedup_key == revised.dedup_key
+    assert first.interval_start == revised.interval_start

--- a/tests/test_sleep_stage_normalization.py
+++ b/tests/test_sleep_stage_normalization.py
@@ -44,8 +44,8 @@ def test_shared_sleep_stage_values_normalize_as_ranged_categorical_observations(
     )
 
     assert result.rejected == 0
-    assert NORMALIZER_VERSION == "0.3.0"
-    assert {observation.normalizer_version for observation in result.observations} == {"0.3.0"}
+    assert NORMALIZER_VERSION == "0.4.0"
+    assert {observation.normalizer_version for observation in result.observations} == {"0.4.0"}
     assert [observation.value.code for observation in result.observations] == [
         code for _, code in expected
     ]


### PR DESCRIPTION
## Symptom

Active Energy and Exercise Minutes stay stuck on "waiting" / "No numeric readings" in the v2 web dashboard, even though the data syncs fine and Grafana/the legacy projection show it. The API logs a recurring `dual-write divergence for activity_summaries: canonical_accepted=0 projection_accepted=1` on every sync.

## Root cause

The iOS client bundles the daily activity-ring totals (`activeEnergyBurned`, `appleExerciseTime`, `appleStandHours`) into a single `activity_summaries` wire metric, instead of sending them as individual per-metric quantity batches (the shape every other wire metric uses — including the *same* totals when sent standalone).

`_apple_wire_index()` only indexes `source_metric` names declared on individual `MetricDefinition`s, so `activity_summaries` itself never resolves to a canonical metric. `normalize_apple_batch` silently produced **zero** canonical observations for the whole batch, while the legacy `daily_activity` projection kept writing correctly — a persistent dual-write divergence that's easy to miss because 4 of 7 activity metrics (`step_count`, `distance_walking_running`, `flights_climbed`, `basal_energy_burned`) DO arrive as separate batches and work fine.

Verified live against a self-hosted instance: `canonical_observations` had 0 rows ever for `activity.active_energy` / `activity.exercise_minutes`, while `daily_activity` had 28 days of correct values.

## Fix

- Expand each `activity_summaries` sample into its constituent wire-metric fields (`active_energy_burned`, `apple_exercise_time`) and route them through the existing per-metric normalization path.
- Stamp the `HealthKit Statistics` origin on the derived samples so they take the stable daily-total dedup identity — a later same-day revision replaces rather than appends.
- `appleStandHours` is **intentionally left unmapped**: it's a 0-24 hour COUNT, not a minutes total, so mapping it straight into `activity.stand_minutes` (unit `min`) would silently corrupt the value. That needs its own ontology metric, not a blind field rename.
- Registers `activity_summaries` in `contracts/parity.json` (every wire metric is a recorded parity decision).
- Bumps `NORMALIZER_VERSION` to `0.4.0` and updates the two contract tests that pin the previous version.
- Adds a golden fixture + two regression tests covering the expansion and same-day revision stability.

## Verification

- New tests pass: `test_activity_summaries_batch_expands_into_per_metric_observations`, `test_activity_summaries_same_day_revision_keeps_stable_identity`.
- Full suite: 1390 passed, 48 skipped, 0 new failures (the only local failures are 4 `test_remote_vm_deploy.py` cases that need a `docker` binary — confirmed identical/pre-existing on a clean `main` checkout with no relation to this change).
- Backfilled a real instance by replaying its stored `activity_summaries` raw payloads through the fixed normalizer: `canonical_observations` now has 28 days of `activity.active_energy` / `activity.exercise_minutes` matching `daily_activity` exactly, and the v2 series API returns the expected values instead of empty point lists.
